### PR TITLE
[3/5] Improve discovery, tournament, and team interfaces

### DIFF
--- a/elapse_app/lib/screens/explore/explore.dart
+++ b/elapse_app/lib/screens/explore/explore.dart
@@ -1,6 +1,5 @@
 import 'package:elapse_app/screens/explore/search.dart';
 import 'package:elapse_app/screens/explore/worldRankings.dart';
-import 'package:elapse_app/screens/explore/worldRankings/skills/world_skills.dart';
 import 'package:elapse_app/screens/explore/upcoming_tournaments.dart';
 import 'package:elapse_app/screens/explore/worldRankings/topWorldSkills.dart';
 import 'package:elapse_app/screens/widgets/app_bar.dart';
@@ -40,9 +39,13 @@ class ExploreScreen extends StatelessWidget {
                         context,
                         PageRouteBuilder(
                           transitionDuration: const Duration(milliseconds: 300),
-                          reverseTransitionDuration: const Duration(milliseconds: 300),
-                          pageBuilder: (context, animation, secondaryAnimation) => ExploreSearch(),
-                          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+                          reverseTransitionDuration:
+                              const Duration(milliseconds: 300),
+                          pageBuilder:
+                              (context, animation, secondaryAnimation) =>
+                                  ExploreSearch(),
+                          transitionsBuilder:
+                              (context, animation, secondaryAnimation, child) {
                             // Create a Tween that transitions the new screen from fully transparent to fully opaque
                             return FadeTransition(
                               opacity: animation,
@@ -174,13 +177,17 @@ class ExploreScreen extends StatelessWidget {
               margin: const EdgeInsets.symmetric(horizontal: 23),
               padding: EdgeInsets.symmetric(horizontal: 10),
               height: 64,
-              decoration:
-                  BoxDecoration(color: Theme.of(context).colorScheme.tertiary, borderRadius: BorderRadius.circular(18)),
+              decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.tertiary,
+                  borderRadius: BorderRadius.circular(18)),
               child: TextButton(
                 style: TextButton.styleFrom(overlayColor: Colors.transparent),
                 onPressed: () {
                   Navigator.push(
-                      context, MaterialPageRoute(builder: (context) => const WorldRankingsScreen(initIndex: 0)));
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) =>
+                              const WorldRankingsScreen(initIndex: 0)));
                 },
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -224,7 +231,8 @@ class ExploreScreen extends StatelessWidget {
                       margin: const EdgeInsets.only(top: 18),
                       padding: const EdgeInsets.symmetric(horizontal: 10),
                       decoration: BoxDecoration(
-                        border: Border.all(color: Theme.of(context).colorScheme.primary),
+                        border: Border.all(
+                            color: Theme.of(context).colorScheme.primary),
                         borderRadius: BorderRadius.circular(18),
                       ),
                       child: ShaderMask(
@@ -234,19 +242,33 @@ class ExploreScreen extends StatelessWidget {
                             end: Alignment.bottomCenter,
                             colors: [
                               Theme.of(context).colorScheme.surface,
-                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
+                              Theme.of(context)
+                                  .colorScheme
+                                  .surface
+                                  .withValues(alpha: 0),
+                              Theme.of(context)
+                                  .colorScheme
+                                  .surface
+                                  .withValues(alpha: 0),
                               Theme.of(context).colorScheme.surface
                             ],
-                            stops: const [0.0, 0.1, 0.9, 1.0], // 10% purple, 80% transparent, 10% purple
+                            stops: const [
+                              0.0,
+                              0.1,
+                              0.9,
+                              1.0
+                            ], // 10% purple, 80% transparent, 10% purple
                           ).createShader(rect);
                         },
                         blendMode: BlendMode.dstOut,
                         child: UpcomingTournaments(
                             filter: ExploreSearchFilter(
                                 startDate: DateTime.now(),
-                                endDate: DateTime.now().add(const Duration(days: 60)),
-                                location: loadTeamPreview(prefs.getString("savedTeam")).location)),
+                                endDate: DateTime.now()
+                                    .add(const Duration(days: 60)),
+                                location: loadTeamPreview(
+                                        prefs.getString("savedTeam"))
+                                    .location)),
                       ))
                 ],
               ),
@@ -273,7 +295,8 @@ class ExploreScreen extends StatelessWidget {
                       margin: const EdgeInsets.only(top: 18),
                       padding: const EdgeInsets.symmetric(horizontal: 10),
                       decoration: BoxDecoration(
-                        border: Border.all(color: Theme.of(context).colorScheme.primary),
+                        border: Border.all(
+                            color: Theme.of(context).colorScheme.primary),
                         borderRadius: BorderRadius.circular(18),
                       ),
                       child: ShaderMask(
@@ -283,11 +306,22 @@ class ExploreScreen extends StatelessWidget {
                             end: Alignment.bottomCenter,
                             colors: [
                               Theme.of(context).colorScheme.surface,
-                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
+                              Theme.of(context)
+                                  .colorScheme
+                                  .surface
+                                  .withValues(alpha: 0),
+                              Theme.of(context)
+                                  .colorScheme
+                                  .surface
+                                  .withValues(alpha: 0),
                               Theme.of(context).colorScheme.surface
                             ],
-                            stops: const [0.0, 0.1, 0.9, 1.0], // 10% purple, 80% transparent, 10% purple
+                            stops: const [
+                              0.0,
+                              0.1,
+                              0.9,
+                              1.0
+                            ], // 10% purple, 80% transparent, 10% purple
                           ).createShader(rect);
                         },
                         blendMode: BlendMode.dstOut,
@@ -295,7 +329,8 @@ class ExploreScreen extends StatelessWidget {
                             filter: ExploreSearchFilter(
                                 levelClass: levelClasses[4],
                                 startDate: DateTime.now(),
-                                endDate: DateTime.now().add(const Duration(days: 60)))),
+                                endDate: DateTime.now()
+                                    .add(const Duration(days: 60)))),
                       ))
                 ],
               ),
@@ -322,7 +357,8 @@ class ExploreScreen extends StatelessWidget {
                       margin: const EdgeInsets.only(top: 18),
                       padding: const EdgeInsets.symmetric(horizontal: 10),
                       decoration: BoxDecoration(
-                        border: Border.all(color: Theme.of(context).colorScheme.primary),
+                        border: Border.all(
+                            color: Theme.of(context).colorScheme.primary),
                         borderRadius: BorderRadius.circular(18),
                       ),
                       child: ShaderMask(
@@ -332,11 +368,22 @@ class ExploreScreen extends StatelessWidget {
                             end: Alignment.bottomCenter,
                             colors: [
                               Theme.of(context).colorScheme.surface,
-                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
+                              Theme.of(context)
+                                  .colorScheme
+                                  .surface
+                                  .withValues(alpha: 0),
+                              Theme.of(context)
+                                  .colorScheme
+                                  .surface
+                                  .withValues(alpha: 0),
                               Theme.of(context).colorScheme.surface
                             ],
-                            stops: const [0.0, 0.1, 0.9, 1.0], // 10% purple, 80% transparent, 10% purple
+                            stops: const [
+                              0.0,
+                              0.1,
+                              0.9,
+                              1.0
+                            ], // 10% purple, 80% transparent, 10% purple
                           ).createShader(rect);
                         },
                         blendMode: BlendMode.dstOut,

--- a/elapse_app/lib/screens/explore/filters.dart
+++ b/elapse_app/lib/screens/explore/filters.dart
@@ -21,14 +21,17 @@ class ExploreSearchFilter {
     DateTime? startDate,
     DateTime? endDate,
     this.location,
-  })  : this.season = season ?? seasons[0],
-        this.levelClass = levelClass ?? levelClasses[0],
-        this.gradeLevel = gradeLevel ?? getGradeLevel(prefs.getString("defaultGrade")),
-        this.startDate = startDate ?? DateTime.now(),
-        this.endDate = endDate ?? DateTime((season ?? seasons[0]).endYear.year, 4, 30);
+  })  : season = season ?? seasons[0],
+        levelClass = levelClass ?? levelClasses[0],
+        gradeLevel =
+            gradeLevel ?? getGradeLevel(prefs.getString("defaultGrade")),
+        startDate = startDate ?? DateTime.now(),
+        endDate =
+            endDate ?? DateTime((season ?? seasons[0]).endYear.year, 4, 30);
 }
 
-Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFilter filter) async {
+Future<ExploreSearchFilter> exploreFilter(
+    BuildContext context, ExploreSearchFilter filter) async {
   final DraggableScrollableController dra = DraggableScrollableController();
 
   List<GradeLevel> gradeFilters = gradeLevels.values.toList();
@@ -48,9 +51,11 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                 shouldCloseOnMinExtent: true,
                 snapAnimationDuration: const Duration(milliseconds: 250),
                 controller: dra,
-                builder: (BuildContext context, ScrollController scrollController) {
+                builder:
+                    (BuildContext context, ScrollController scrollController) {
                   return Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 23, vertical: 24),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 23, vertical: 24),
                       decoration: BoxDecoration(
                         color: Theme.of(context).colorScheme.surface,
                         borderRadius: const BorderRadius.only(
@@ -73,14 +78,20 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                               ),
                               filter.season != seasons[0] ||
                                       filter.levelClass != levelClasses[0] ||
-                                      filter.startDate != DateTime(filter.season.startYear.year, 5, 1) ||
-                                      filter.endDate != DateTime(filter.season.endYear.year, 4, 30)
+                                      filter.startDate !=
+                                          DateTime(filter.season.startYear.year,
+                                              5, 1) ||
+                                      filter.endDate !=
+                                          DateTime(
+                                              filter.season.endYear.year, 4, 30)
                                   ? TextButton(
                                       child: Text("Reset",
                                           style: TextStyle(
                                             fontSize: 16,
                                             height: 1,
-                                            color: Theme.of(context).colorScheme.secondary,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .secondary,
                                             fontWeight: FontWeight.w400,
                                           )),
                                       onPressed: () {
@@ -102,17 +113,22 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                           padding: const EdgeInsets.only(left: 20, right: 20),
                           decoration: BoxDecoration(
                             color: Theme.of(context).colorScheme.surface,
-                            border: Border.all(color: Theme.of(context).colorScheme.primary),
-                            borderRadius: const BorderRadius.all(Radius.circular(100)),
+                            border: Border.all(
+                                color: Theme.of(context).colorScheme.primary),
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(100)),
                           ),
                           child: InkWell(
-                            child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
-                              const Icon(Icons.event_note),
-                              const SizedBox(width: 10),
-                              Text(filter.season.name, style: const TextStyle(fontSize: 16)),
-                              const Spacer(),
-                              const Icon(Icons.arrow_right),
-                            ]),
+                            child: Row(
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                children: [
+                                  const Icon(Icons.event_note),
+                                  const SizedBox(width: 10),
+                                  Text(filter.season.name,
+                                      style: const TextStyle(fontSize: 16)),
+                                  const Spacer(),
+                                  const Icon(Icons.arrow_right),
+                                ]),
                             onTap: () async {
                               Season updated = await Navigator.push(
                                 context,
@@ -124,8 +140,10 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                               );
                               setModalState(() {
                                 filter.season = updated;
-                                filter.startDate = DateTime(filter.season.startYear.year, 5, 1);
-                                filter.endDate = DateTime(filter.season.endYear.year, 4, 30);
+                                filter.startDate = DateTime(
+                                    filter.season.startYear.year, 5, 1);
+                                filter.endDate =
+                                    DateTime(filter.season.endYear.year, 4, 30);
                               });
                             },
                           ),
@@ -138,17 +156,22 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                           padding: const EdgeInsets.only(left: 20, right: 20),
                           decoration: BoxDecoration(
                             color: Theme.of(context).colorScheme.surface,
-                            border: Border.all(color: Theme.of(context).colorScheme.primary),
-                            borderRadius: const BorderRadius.all(Radius.circular(100)),
+                            border: Border.all(
+                                color: Theme.of(context).colorScheme.primary),
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(100)),
                           ),
                           child: InkWell(
-                            child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
-                              const Icon(Icons.language),
-                              const SizedBox(width: 10),
-                              Text(filter.levelClass.name, style: const TextStyle(fontSize: 16)),
-                              const Spacer(),
-                              const Icon(Icons.arrow_right),
-                            ]),
+                            child: Row(
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                children: [
+                                  const Icon(Icons.language),
+                                  const SizedBox(width: 10),
+                                  Text(filter.levelClass.name,
+                                      style: const TextStyle(fontSize: 16)),
+                                  const Spacer(),
+                                  const Icon(Icons.arrow_right),
+                                ]),
                             onTap: () async {
                               LevelClass updated = await Navigator.push(
                                 context,
@@ -170,8 +193,10 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                             padding: const EdgeInsets.only(left: 20, right: 20),
                             decoration: BoxDecoration(
                               color: Theme.of(context).colorScheme.surface,
-                              border: Border.all(color: Theme.of(context).colorScheme.primary),
-                              borderRadius: const BorderRadius.all(Radius.circular(100)),
+                              border: Border.all(
+                                  color: Theme.of(context).colorScheme.primary),
+                              borderRadius:
+                                  const BorderRadius.all(Radius.circular(100)),
                             ),
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.start,
@@ -184,7 +209,8 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                                     return DropdownMenuItem(
                                       value: grade,
                                       child: Text(grade.name,
-                                          overflow: TextOverflow.fade, style: const TextStyle(fontSize: 16)),
+                                          overflow: TextOverflow.fade,
+                                          style: const TextStyle(fontSize: 16)),
                                     );
                                   }).toList(),
                                   onChanged: (GradeLevel? value) => {
@@ -201,17 +227,21 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                           padding: const EdgeInsets.only(left: 20, right: 20),
                           decoration: BoxDecoration(
                             color: Theme.of(context).colorScheme.surface,
-                            border: Border.all(color: Theme.of(context).colorScheme.primary),
-                            borderRadius: const BorderRadius.all(Radius.circular(100)),
+                            border: Border.all(
+                                color: Theme.of(context).colorScheme.primary),
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(100)),
                           ),
                           child: InkWell(
-                            child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
-                              const Icon(Icons.calendar_month),
-                              const SizedBox(width: 10),
-                              Text(
-                                  "Start Date: ${filter.startDate.month}/${filter.startDate.day}/${filter.startDate.year}",
-                                  style: const TextStyle(fontSize: 16)),
-                            ]),
+                            child: Row(
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                children: [
+                                  const Icon(Icons.calendar_month),
+                                  const SizedBox(width: 10),
+                                  Text(
+                                      "Start Date: ${filter.startDate.month}/${filter.startDate.day}/${filter.startDate.year}",
+                                      style: const TextStyle(fontSize: 16)),
+                                ]),
                             onTap: () async {
                               final DateTime? date = await showDatePicker(
                                 context: context,
@@ -233,16 +263,21 @@ Future<ExploreSearchFilter> exploreFilter(BuildContext context, ExploreSearchFil
                           padding: const EdgeInsets.only(left: 20, right: 20),
                           decoration: BoxDecoration(
                             color: Theme.of(context).colorScheme.surface,
-                            border: Border.all(color: Theme.of(context).colorScheme.primary),
-                            borderRadius: const BorderRadius.all(Radius.circular(100)),
+                            border: Border.all(
+                                color: Theme.of(context).colorScheme.primary),
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(100)),
                           ),
                           child: InkWell(
-                            child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
-                              const Icon(Icons.calendar_month),
-                              const SizedBox(width: 10),
-                              Text("End Date: ${filter.endDate.month}/${filter.endDate.day}/${filter.endDate.year}",
-                                  style: const TextStyle(fontSize: 16)),
-                            ]),
+                            child: Row(
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                children: [
+                                  const Icon(Icons.calendar_month),
+                                  const SizedBox(width: 10),
+                                  Text(
+                                      "End Date: ${filter.endDate.month}/${filter.endDate.day}/${filter.endDate.year}",
+                                      style: const TextStyle(fontSize: 16)),
+                                ]),
                             onTap: () async {
                               final DateTime? date = await showDatePicker(
                                 context: context,

--- a/elapse_app/lib/screens/explore/search.dart
+++ b/elapse_app/lib/screens/explore/search.dart
@@ -19,7 +19,8 @@ class ExploreSearch extends StatefulWidget {
   State<ExploreSearch> createState() => _ExploreSearchState();
 }
 
-class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateMixin {
+class _ExploreSearchState extends State<ExploreSearch>
+    with TickerProviderStateMixin {
   final FocusNode _focusNode = FocusNode();
   String searchQuery = "";
   int selectedIndex = 0;
@@ -42,7 +43,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
       _focusNode.requestFocus();
     });
 
-    List<String> recentTeamStrings = prefs.getStringList("recentTeamSearches") ?? <String>[];
+    List<String> recentTeamStrings =
+        prefs.getStringList("recentTeamSearches") ?? <String>[];
 
     for (int i = recentTeamStrings.length - 1; i >= 0; i--) {
       var json = jsonDecode(recentTeamStrings[i]);
@@ -52,7 +54,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
       ));
     }
 
-    List<String> recentTournamentStrings = prefs.getStringList("recentTournamentSearches") ?? <String>[];
+    List<String> recentTournamentStrings =
+        prefs.getStringList("recentTournamentSearches") ?? <String>[];
 
     for (int i = recentTournamentStrings.length - 1; i >= 0; i--) {
       var json = jsonDecode(recentTournamentStrings[i]);
@@ -112,7 +115,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                               Spacer(),
                               Flex(
                                 direction: Axis.horizontal,
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
                                   Flexible(
                                       flex: 1,
@@ -130,29 +134,41 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                       focusNode: _focusNode,
                                       textInputAction: TextInputAction.search,
                                       onSubmitted: _onSearchSubmitted,
-                                      cursorColor: Theme.of(context).colorScheme.secondary,
+                                      cursorColor: Theme.of(context)
+                                          .colorScheme
+                                          .secondary,
                                       decoration: const InputDecoration(
-                                          hintText: "Search teams or tournaments", border: InputBorder.none),
+                                          hintText:
+                                              "Search teams or tournaments",
+                                          border: InputBorder.none),
                                     ),
                                   ),
                                 ],
                               ),
                               Spacer(),
                               if (constraints.maxHeight - 135 + 45 > 0)
-                                Container(
-                                  height: containerHeight > 130 ? 45 : containerHeight - 130 + 45,
+                                SizedBox(
+                                  height: containerHeight > 130
+                                      ? 45
+                                      : containerHeight - 130 + 45,
                                   child: Flex(
                                     direction: Axis.horizontal,
-                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
                                     children: [
                                       Flexible(
                                         flex: 3,
-                                        child: FilterButton(0, constraints.maxHeight, "Teams"),
+                                        child: FilterButton(
+                                            0, constraints.maxHeight, "Teams"),
                                       ),
                                       Flexible(
                                         flex: 3,
-                                        child: FilterButton(1, constraints.maxHeight, "Tournaments"),
+                                        child: FilterButton(
+                                            1,
+                                            constraints.maxHeight,
+                                            "Tournaments"),
                                       ),
                                       Flexible(
                                           flex: 1,
@@ -162,16 +178,30 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                                   icon: Icon(
                                                     Icons.filter_list_outlined,
                                                     size: 20,
-                                                    color: Theme.of(context).colorScheme.secondary.withValues(
-                                                        alpha: ((constraints.maxHeight - 110) / 20) > 1
-                                                            ? 1
-                                                            : (constraints.maxHeight - 110) / 20),
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary
+                                                        .withValues(
+                                                            alpha: ((constraints.maxHeight -
+                                                                            110) /
+                                                                        20) >
+                                                                    1
+                                                                ? 1
+                                                                : (constraints
+                                                                            .maxHeight -
+                                                                        110) /
+                                                                    20),
                                                   ),
                                                   onPressed: () async {
-                                                    final result = await exploreFilter(context, filter);
+                                                    final result =
+                                                        await exploreFilter(
+                                                            context, filter);
                                                     setState(() {
                                                       filter = result;
-                                                      tournamentSearch = getTournaments(searchQuery, filter);
+                                                      tournamentSearch =
+                                                          getTournaments(
+                                                              searchQuery,
+                                                              filter);
                                                     });
                                                   },
                                                 )
@@ -207,7 +237,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                     ),
                     Container(
                       height: 60,
-                      padding: const EdgeInsets.symmetric(horizontal: 23, vertical: 10),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 23, vertical: 10),
                       decoration: BoxDecoration(
                         color: Theme.of(context).colorScheme.surface,
                         borderRadius: const BorderRadius.only(
@@ -220,7 +251,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                         children: [
                           Text(
                             titles[selectedIndex + 1],
-                            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
+                            style: const TextStyle(
+                                fontSize: 18, fontWeight: FontWeight.w500),
                           ),
                           selectedIndex == 1
                               ? FutureBuilder(
@@ -236,7 +268,9 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                                   () {
                                                     currentPage -= 1;
                                                     tournamentSearch =
-                                                        getTournaments(searchQuery, filter, page: currentPage);
+                                                        getTournaments(
+                                                            searchQuery, filter,
+                                                            page: currentPage);
                                                   },
                                                 );
                                               }
@@ -258,15 +292,20 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                             },
                                             child: AnimatedOpacity(
                                               opacity: leftOpacity,
-                                              duration: const Duration(milliseconds: 150),
+                                              duration: const Duration(
+                                                  milliseconds: 150),
                                               child: Icon(
                                                 Icons.arrow_back_ios_outlined,
                                                 color: currentPage != 1
                                                     ? Theme.of(context)
                                                         .colorScheme
                                                         .secondary
-                                                        .withValues(alpha: rightOpacity)
-                                                    : Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+                                                        .withValues(
+                                                            alpha: rightOpacity)
+                                                    : Theme.of(context)
+                                                        .colorScheme
+                                                        .onSurface
+                                                        .withValues(alpha: 0.5),
                                                 size: 20,
                                               ),
                                             ),
@@ -283,12 +322,15 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                           ),
                                           GestureDetector(
                                             onTap: () {
-                                              if (currentPage != snapshot.data?.maxPage) {
+                                              if (currentPage !=
+                                                  snapshot.data?.maxPage) {
                                                 setState(
                                                   () {
                                                     currentPage += 1;
                                                     tournamentSearch =
-                                                        getTournaments(searchQuery, filter, page: currentPage);
+                                                        getTournaments(
+                                                            searchQuery, filter,
+                                                            page: currentPage);
                                                   },
                                                 );
                                               }
@@ -310,15 +352,21 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                             },
                                             child: AnimatedOpacity(
                                               opacity: rightOpacity,
-                                              duration: const Duration(milliseconds: 150),
+                                              duration: const Duration(
+                                                  milliseconds: 150),
                                               child: Icon(
                                                 Icons.arrow_forward_ios_rounded,
-                                                color: currentPage != snapshot.data?.maxPage
+                                                color: currentPage !=
+                                                        snapshot.data?.maxPage
                                                     ? Theme.of(context)
                                                         .colorScheme
                                                         .secondary
-                                                        .withValues(alpha: rightOpacity)
-                                                    : Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+                                                        .withValues(
+                                                            alpha: rightOpacity)
+                                                    : Theme.of(context)
+                                                        .colorScheme
+                                                        .onSurface
+                                                        .withValues(alpha: 0.5),
                                                 size: 20,
                                               ),
                                             ),
@@ -330,7 +378,9 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                         children: [
                                           Icon(
                                             Icons.arrow_back_ios_outlined,
-                                            color: Theme.of(context).colorScheme.surfaceDim,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .surfaceDim,
                                             size: 20,
                                           ),
                                           const SizedBox(
@@ -338,7 +388,9 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                           ),
                                           Icon(
                                             Icons.arrow_forward_ios_outlined,
-                                            color: Theme.of(context).colorScheme.surfaceDim,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .surfaceDim,
                                             size: 20,
                                           ),
                                         ],
@@ -376,7 +428,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
               );
             } else if (snapshot.hasData) {
               if (snapshot.data?.isEmpty ?? true) {
-                return const BigErrorMessage(icon: Icons.search_off_outlined, message: "No Teams Found");
+                return const BigErrorMessage(
+                    icon: Icons.search_off_outlined, message: "No Teams Found");
               }
               final uniqueTeams = snapshot.data!.toSet().toList();
               return Column(
@@ -392,13 +445,15 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                   saveSearch: true,
                                   saveState: () {
                                     setState(() {
-                                      recentTeamSearches
-                                          .add(RecentTeamSearch(searchTerm: team.teamNumber, teamID: team.teamID));
+                                      recentTeamSearches.add(RecentTeamSearch(
+                                          searchTerm: team.teamNumber,
+                                          teamID: team.teamID));
                                     });
                                   },
                                 ),
                                 Divider(
-                                  color: Theme.of(context).colorScheme.surfaceDim,
+                                  color:
+                                      Theme.of(context).colorScheme.surfaceDim,
                                 )
                               ],
                             ))
@@ -434,7 +489,10 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                         children: [
                                           Icon(
                                             Icons.history_rounded,
-                                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .onSurface
+                                                .withValues(alpha: 0.7),
                                           ),
                                           const SizedBox(
                                             width: 15,
@@ -443,13 +501,18 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                             e.searchTerm,
                                             style: TextStyle(
                                               fontSize: 24,
-                                              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onSurface
+                                                  .withValues(alpha: 0.7),
                                             ),
                                           ),
                                         ],
                                       ),
                                       Divider(
-                                        color: Theme.of(context).colorScheme.surfaceDim,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceDim,
                                       )
                                     ],
                                   ),
@@ -459,7 +522,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                     ),
                     TextButton(
                       style: TextButton.styleFrom(
-                          padding: const EdgeInsets.only(left: 0, top: 10, right: 10, bottom: 10),
+                          padding: const EdgeInsets.only(
+                              left: 0, top: 10, right: 10, bottom: 10),
                           minimumSize: Size(50, 30),
                           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                           alignment: Alignment.centerLeft),
@@ -472,7 +536,9 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                       child: Text(
                         "Clear Searches",
                         style: TextStyle(
-                            color: Theme.of(context).colorScheme.secondary, fontWeight: FontWeight.w500, fontSize: 14),
+                            color: Theme.of(context).colorScheme.secondary,
+                            fontWeight: FontWeight.w500,
+                            fontSize: 14),
                       ),
                     )
                   ],
@@ -512,9 +578,12 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
             }
             if (snapshot.hasData) {
               if (snapshot.data?.tournaments.isEmpty == true) {
-                return const BigErrorMessage(icon: Icons.search_off_outlined, message: "No Tournaments Found");
+                return const BigErrorMessage(
+                    icon: Icons.search_off_outlined,
+                    message: "No Tournaments Found");
               }
-              List<TournamentPreview> tournaments = snapshot.data?.tournaments ?? [];
+              List<TournamentPreview> tournaments =
+                  snapshot.data?.tournaments ?? [];
               return Column(
                   children: tournaments
                           .map<Widget>((e) => TournamentPreviewWidget(
@@ -522,8 +591,10 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                 saveSearch: true,
                                 saveState: () {
                                   setState(() {
-                                    recentTournamentSearches
-                                        .add(RecentTournamentSearch(searchTerm: e.name, tournamentID: e.id));
+                                    recentTournamentSearches.add(
+                                        RecentTournamentSearch(
+                                            searchTerm: e.name,
+                                            tournamentID: e.id));
                                   });
                                 },
                               ))
@@ -559,7 +630,10 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                         children: [
                                           Icon(
                                             Icons.history_rounded,
-                                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .onSurface
+                                                .withValues(alpha: 0.7),
                                           ),
                                           const SizedBox(
                                             width: 15,
@@ -569,7 +643,10 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                               e.searchTerm,
                                               style: TextStyle(
                                                 fontSize: 18,
-                                                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .onSurface
+                                                    .withValues(alpha: 0.7),
                                               ),
                                               maxLines: 1,
                                               overflow: TextOverflow.ellipsis,
@@ -578,7 +655,9 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                                         ],
                                       ),
                                       Divider(
-                                        color: Theme.of(context).colorScheme.surfaceDim,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceDim,
                                       )
                                     ],
                                   ),
@@ -588,7 +667,8 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                     ),
                     TextButton(
                       style: TextButton.styleFrom(
-                          padding: const EdgeInsets.only(left: 0, top: 10, right: 10, bottom: 10),
+                          padding: const EdgeInsets.only(
+                              left: 0, top: 10, right: 10, bottom: 10),
                           minimumSize: Size(50, 30),
                           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                           alignment: Alignment.centerLeft),
@@ -601,7 +681,9 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
                       child: Text(
                         "Clear Searches",
                         style: TextStyle(
-                            color: Theme.of(context).colorScheme.secondary, fontWeight: FontWeight.w500, fontSize: 14),
+                            color: Theme.of(context).colorScheme.secondary,
+                            fontWeight: FontWeight.w500,
+                            fontSize: 14),
                       ),
                     )
                   ],
@@ -656,27 +738,29 @@ class _ExploreSearchState extends State<ExploreSearch> with TickerProviderStateM
       },
       child: AnimatedContainer(
         curve: Curves.fastOutSlowIn,
-        duration: const Duration(milliseconds: 300), // Duration of the animation
+        duration:
+            const Duration(milliseconds: 300), // Duration of the animation
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: selectedIndex == buttonIndex
-              ? selectedContainerColor.withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)
-              : unselectedContainerColor.withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+              ? selectedContainerColor.withValues(
+                  alpha:
+                      ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)
+              : unselectedContainerColor.withValues(
+                  alpha:
+                      ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
           border: Border.all(
               width: 1.5,
-              color: Theme.of(context)
-                  .colorScheme
-                  .primary
-                  .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)),
+              color: Theme.of(context).colorScheme.primary.withValues(
+                  alpha:
+                      ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)),
           borderRadius: borderRadius,
         ),
         child: Text(
           text,
           style: TextStyle(
-            color: Theme.of(context)
-                .colorScheme
-                .secondary
-                .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+            color: Theme.of(context).colorScheme.secondary.withValues(
+                alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
             fontSize: 14,
             fontWeight: FontWeight.w500,
           ),

--- a/elapse_app/lib/screens/explore/upcoming_tournaments.dart
+++ b/elapse_app/lib/screens/explore/upcoming_tournaments.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 

--- a/elapse_app/lib/screens/explore/worldRankings.dart
+++ b/elapse_app/lib/screens/explore/worldRankings.dart
@@ -15,7 +15,6 @@ import '../../classes/Team/world_skills.dart';
 import '../../classes/Tournament/tournament.dart';
 import '../my_team/my_team.dart';
 import '../widgets/app_bar.dart';
-import '../widgets/big_error_message.dart';
 import '../widgets/custom_tab_bar.dart';
 
 class WorldRankingsScreen extends StatefulWidget {
@@ -45,7 +44,13 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
   List<String> pageTitles = ["Skills", "TrueSkill"];
 
   int sortIndex = 0;
-  List<String> skillsSort = ["Total", "Driver", "Auton", "Highest Driver", "Highest Auton"];
+  List<String> skillsSort = [
+    "Total",
+    "Driver",
+    "Auton",
+    "Highest Driver",
+    "Highest Auton"
+  ];
   List<String> tsSort = ["Score", "OPR", "DPR", "CCWM", "Win %"];
 
   double _fadeStart = 0, _fadeEnd = 1;
@@ -62,8 +67,10 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
 
     isSkillsLoaded = false;
     isVDALoaded = false;
-    futureSkillsStats =
-        getWorldSkillsRankings((grade == gradeLevels["College"] ? season.vexUId! : season.vrcId), grade).then((data) {
+    futureSkillsStats = getWorldSkillsRankings(
+            (grade == gradeLevels["College"] ? season.vexUId! : season.vrcId),
+            grade)
+        .then((data) {
       setState(() {
         isSkillsLoaded = true;
         loadedSkills = data;
@@ -80,7 +87,9 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
     });
     futures.add(futureVDAStats);
     savedTeams = _getSavedTeams();
-    picklistTeams = (prefs.getStringList("picklist") ?? []).map((e) => loadTeamPreview(e)).toList();
+    picklistTeams = (prefs.getStringList("picklist") ?? [])
+        .map((e) => loadTeamPreview(e))
+        .toList();
     inTM = prefs.getBool("isTournamentMode") ?? false;
   }
 
@@ -112,12 +121,19 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                                 Navigator.push(
                                   context,
                                   PageRouteBuilder(
-                                    transitionDuration: const Duration(milliseconds: 300),
-                                    reverseTransitionDuration: const Duration(milliseconds: 300),
-                                    pageBuilder: (context, animation, secondaryAnimation) => WorldRankingsSearchScreen(
-                                        skills: snapshot.data![0] as List<WorldSkillsStats>,
-                                        vda: snapshot.data![1] as List<VDAStats>),
-                                    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+                                    transitionDuration:
+                                        const Duration(milliseconds: 300),
+                                    reverseTransitionDuration:
+                                        const Duration(milliseconds: 300),
+                                    pageBuilder: (context, animation,
+                                            secondaryAnimation) =>
+                                        WorldRankingsSearchScreen(
+                                            skills: snapshot.data![0]
+                                                as List<WorldSkillsStats>,
+                                            vda: snapshot.data![1]
+                                                as List<VDAStats>),
+                                    transitionsBuilder: (context, animation,
+                                        secondaryAnimation, child) {
                                       return FadeTransition(
                                         opacity: animation,
                                         child: child,
@@ -142,7 +158,8 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                     onTap: () {
                       Navigator.pop(context);
                     },
-                    child: Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.onSurface),
+                    child: Icon(Icons.arrow_back,
+                        color: Theme.of(context).colorScheme.onSurface),
                   ),
                   const Spacer(),
                   Row(children: [
@@ -154,7 +171,8 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                         return DropdownMenuItem(
                           value: grade,
                           child: Text(getGrade(grade.name),
-                              overflow: TextOverflow.fade, style: const TextStyle(fontSize: 16)),
+                              overflow: TextOverflow.fade,
+                              style: const TextStyle(fontSize: 16)),
                         );
                       }).toList(),
                       onChanged: (GradeLevel? value) => {
@@ -162,7 +180,10 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                           grade = value!;
                           isSkillsLoaded = false;
                           futureSkillsStats = getWorldSkillsRankings(
-                                  grade == gradeLevels["College"] ? season.vexUId! : season.vrcId, grade)
+                                  grade == gradeLevels["College"]
+                                      ? season.vexUId!
+                                      : season.vrcId,
+                                  grade)
                               .then((data) {
                             setState(() {
                               isSkillsLoaded = true;
@@ -183,14 +204,20 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                           MaterialPageRoute(
                             builder: (context) => SeasonFilterPage(
                                 selected: season,
-                                seasonsList: seasons.sublist(0, seasons.indexWhere((e) => e.vrcId == 115) + 1)),
+                                seasonsList: seasons.sublist(
+                                    0,
+                                    seasons.indexWhere((e) => e.vrcId == 115) +
+                                        1)),
                           ),
                         );
                         setState(() {
                           season = updated;
                           isSkillsLoaded = false;
                           futureSkillsStats = getWorldSkillsRankings(
-                                  grade == gradeLevels["College"] ? season.vexUId! : season.vrcId, grade)
+                                  grade == gradeLevels["College"]
+                                      ? season.vexUId!
+                                      : season.vrcId,
+                                  grade)
                               .then((data) {
                             setState(() {
                               isSkillsLoaded = true;
@@ -199,7 +226,8 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                             return data;
                           });
                           isVDALoaded = false;
-                          futureVDAStats = getTrueSkillData(season.vrcId).then((data) {
+                          futureVDAStats =
+                              getTrueSkillData(season.vrcId).then((data) {
                             setState(() {
                               isVDALoaded = true;
                               loadedVDA = data;
@@ -248,9 +276,11 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                           child: NotificationListener<ScrollNotification>(
                             onNotification: (scrollNotification) {
                               setState(() {
-                                _fadeStart = scrollNotification.metrics.pixels / 10;
-                                _fadeEnd = (scrollNotification.metrics.maxScrollExtent -
-                                    scrollNotification.metrics.pixels) /
+                                _fadeStart =
+                                    scrollNotification.metrics.pixels / 10;
+                                _fadeEnd = (scrollNotification
+                                            .metrics.maxScrollExtent -
+                                        scrollNotification.metrics.pixels) /
                                     10;
 
                                 _fadeStart = _fadeStart.clamp(0.0, 1.0);
@@ -262,23 +292,36 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                               children: [
                                 ListView(
                                   scrollDirection: Axis.horizontal,
-                                  children: List<Widget>.generate(5, (int index) {
+                                  children:
+                                      List<Widget>.generate(5, (int index) {
                                     return Container(
                                       padding: const EdgeInsets.only(right: 5),
                                       child: ChoiceChip(
-                                        padding: const EdgeInsets.symmetric(horizontal: 5),
+                                        padding: const EdgeInsets.symmetric(
+                                            horizontal: 5),
                                         label: Text(skillsSort[index],
                                             style: TextStyle(
-                                              color: Theme.of(context).colorScheme.onSurface,
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onSurface,
                                             )),
                                         selected: sortIndex == index,
                                         shape: RoundedRectangleBorder(
-                                            side: BorderSide(color: Theme.of(context).colorScheme.primary, width: 1.5),
-                                            borderRadius: BorderRadius.circular(10)),
-                                        selectedColor: Theme.of(context).colorScheme.primary,
+                                            side: BorderSide(
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .primary,
+                                                width: 1.5),
+                                            borderRadius:
+                                                BorderRadius.circular(10)),
+                                        selectedColor: Theme.of(context)
+                                            .colorScheme
+                                            .primary,
                                         chipAnimationStyle: ChipAnimationStyle(
-                                            enableAnimation: AnimationStyle(duration: Duration.zero),
-                                            selectAnimation: AnimationStyle(duration: Duration.zero)),
+                                            enableAnimation: AnimationStyle(
+                                                duration: Duration.zero),
+                                            selectAnimation: AnimationStyle(
+                                                duration: Duration.zero)),
                                         onSelected: (bool selected) {
                                           setState(() {
                                             sortIndex = index;
@@ -295,11 +338,22 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                                       gradient: LinearGradient(
                                         colors: [
                                           Theme.of(context).colorScheme.surface,
-                                          Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                                          Theme.of(context).colorScheme.surface.withValues(alpha: 0),
+                                          Theme.of(context)
+                                              .colorScheme
+                                              .surface
+                                              .withValues(alpha: 0),
+                                          Theme.of(context)
+                                              .colorScheme
+                                              .surface
+                                              .withValues(alpha: 0),
                                           Theme.of(context).colorScheme.surface,
                                         ],
-                                        stops: [0, 0.05 * _fadeStart, 1 - 0.05 * _fadeEnd, 1.0],
+                                        stops: [
+                                          0,
+                                          0.05 * _fadeStart,
+                                          1 - 0.05 * _fadeEnd,
+                                          1.0
+                                        ],
                                       ),
                                     ),
                                   ),
@@ -314,7 +368,8 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                             children: [
                               FutureBuilder(
-                                future: Future.wait([futureSkillsStats, futureVDAStats]),
+                                future: Future.wait(
+                                    [futureSkillsStats, futureVDAStats]),
                                 builder: (context, snapshot) {
                                   if (snapshot.hasData) {
                                     return IconButton(
@@ -323,15 +378,21 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                                           size: 30,
                                         ),
                                         onPressed: () async {
-                                          var skills = snapshot.data![0] as List<WorldSkillsStats>;
-                                          var vda = snapshot.data![1] as List<VDAStats>;
-                                          List<String> regions = skills.map((e) => e.eventRegion!.name).toList();
-                                          regions.addAll(vda.map((e) => e.eventRegion!));
+                                          var skills = snapshot.data![0]
+                                              as List<WorldSkillsStats>;
+                                          var vda = snapshot.data![1]
+                                              as List<VDAStats>;
+                                          List<String> regions = skills
+                                              .map((e) => e.eventRegion!.name)
+                                              .toList();
+                                          regions.addAll(
+                                              vda.map((e) => e.eventRegion!));
                                           regions = regions.toSet().toList();
                                           regions.sort();
 
                                           WorldRankingsFilter updatedFilter =
-                                              await worldRankingsFilter(context, filter, inTM, regions);
+                                              await worldRankingsFilter(context,
+                                                  filter, inTM, regions);
                                           setState(() {
                                             filter = updatedFilter;
                                           });
@@ -365,9 +426,11 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                               child: NotificationListener<ScrollNotification>(
                                 onNotification: (scrollNotification) {
                                   setState(() {
-                                    _fadeStart = scrollNotification.metrics.pixels / 10;
-                                    _fadeEnd = (scrollNotification.metrics.maxScrollExtent -
-                                        scrollNotification.metrics.pixels) /
+                                    _fadeStart =
+                                        scrollNotification.metrics.pixels / 10;
+                                    _fadeEnd = (scrollNotification
+                                                .metrics.maxScrollExtent -
+                                            scrollNotification.metrics.pixels) /
                                         10;
 
                                     _fadeStart = _fadeStart.clamp(0.0, 1.0);
@@ -379,24 +442,42 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                                   children: [
                                     ListView(
                                       scrollDirection: Axis.horizontal,
-                                      children: List<Widget>.generate(5, (int index) {
+                                      children:
+                                          List<Widget>.generate(5, (int index) {
                                         return Container(
-                                          padding: const EdgeInsets.only(right: 5),
+                                          padding:
+                                              const EdgeInsets.only(right: 5),
                                           child: ChoiceChip(
-                                            padding: const EdgeInsets.symmetric(horizontal: 5),
+                                            padding: const EdgeInsets.symmetric(
+                                                horizontal: 5),
                                             label: Text(tsSort[index],
                                                 style: TextStyle(
-                                                  color: Theme.of(context).colorScheme.onSurface,
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onSurface,
                                                 )),
                                             shape: RoundedRectangleBorder(
-                                                side:
-                                                BorderSide(color: Theme.of(context).colorScheme.primary, width: 1.5),
-                                                borderRadius: BorderRadius.circular(10)),
+                                                side: BorderSide(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .primary,
+                                                    width: 1.5),
+                                                borderRadius:
+                                                    BorderRadius.circular(10)),
                                             selected: sortIndex == index,
-                                            selectedColor: Theme.of(context).colorScheme.primary,
-                                            chipAnimationStyle: ChipAnimationStyle(
-                                                enableAnimation: AnimationStyle(duration: Duration.zero),
-                                                selectAnimation: AnimationStyle(duration: Duration.zero)),
+                                            selectedColor: Theme.of(context)
+                                                .colorScheme
+                                                .primary,
+                                            chipAnimationStyle:
+                                                ChipAnimationStyle(
+                                                    enableAnimation:
+                                                        AnimationStyle(
+                                                            duration: Duration
+                                                                .zero),
+                                                    selectAnimation:
+                                                        AnimationStyle(
+                                                            duration:
+                                                                Duration.zero)),
                                             onSelected: (bool selected) {
                                               setState(() {
                                                 sortIndex = index;
@@ -412,10 +493,20 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                                         decoration: BoxDecoration(
                                           gradient: LinearGradient(
                                             colors: [
-                                              Theme.of(context).colorScheme.surface,
-                                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                                              Theme.of(context).colorScheme.surface,
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface
+                                                  .withValues(alpha: 0),
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface
+                                                  .withValues(alpha: 0),
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ],
                                             stops: [
                                               0,
@@ -433,40 +524,58 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                             ),
                             Flexible(
                                 flex: 1,
-                                child: Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
-                                  FutureBuilder(
-                                    future: Future.wait([futureSkillsStats, futureVDAStats]),
-                                    builder: (context, snapshot) {
-                                      if (snapshot.hasData) {
-                                        return IconButton(
-                                            icon: const Icon(
-                                              Icons.filter_list,
-                                              size: 30,
-                                            ),
-                                            onPressed: () async {
-                                              var skills = snapshot.data![0] as List<WorldSkillsStats>;
-                                              var vda = snapshot.data![1] as List<VDAStats>;
-                                              List<String> regions = skills.map((e) => e.eventRegion!.name).toList();
-                                              regions.addAll(vda.map((e) => e.eventRegion!));
-                                              regions = regions.toSet().toList();
-                                              regions.sort();
+                                child: Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceEvenly,
+                                    children: [
+                                      FutureBuilder(
+                                        future: Future.wait([
+                                          futureSkillsStats,
+                                          futureVDAStats
+                                        ]),
+                                        builder: (context, snapshot) {
+                                          if (snapshot.hasData) {
+                                            return IconButton(
+                                                icon: const Icon(
+                                                  Icons.filter_list,
+                                                  size: 30,
+                                                ),
+                                                onPressed: () async {
+                                                  var skills = snapshot.data![0]
+                                                      as List<WorldSkillsStats>;
+                                                  var vda = snapshot.data![1]
+                                                      as List<VDAStats>;
+                                                  List<String> regions = skills
+                                                      .map((e) =>
+                                                          e.eventRegion!.name)
+                                                      .toList();
+                                                  regions.addAll(vda.map(
+                                                      (e) => e.eventRegion!));
+                                                  regions =
+                                                      regions.toSet().toList();
+                                                  regions.sort();
 
-                                              WorldRankingsFilter updatedFilter =
-                                                  await worldRankingsFilter(context, filter, inTM, regions);
-                                              setState(() {
-                                                filter = updatedFilter;
-                                              });
-                                            });
-                                      }
-                                      return IconButton(
-                                          icon: const Icon(
-                                            Icons.filter_list,
-                                            size: 30,
-                                          ),
-                                          onPressed: () {});
-                                    },
-                                  )
-                                ]))
+                                                  WorldRankingsFilter
+                                                      updatedFilter =
+                                                      await worldRankingsFilter(
+                                                          context,
+                                                          filter,
+                                                          inTM,
+                                                          regions);
+                                                  setState(() {
+                                                    filter = updatedFilter;
+                                                  });
+                                                });
+                                          }
+                                          return IconButton(
+                                              icon: const Icon(
+                                                Icons.filter_list,
+                                                size: 30,
+                                              ),
+                                              onPressed: () {});
+                                        },
+                                      )
+                                    ]))
                           ],
                         ),
                       ),
@@ -484,7 +593,9 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                 filter: filter,
                 savedTeams: savedTeams,
                 picklistTeams: picklistTeams,
-                tournament: inTM ? loadTournament(prefs.getString("TMSavedTournament")) : null,
+                tournament: inTM
+                    ? loadTournament(prefs.getString("TMSavedTournament"))
+                    : null,
                 scoutedTeams: const [],
               );
             }
@@ -495,7 +606,9 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
                 filter: filter,
                 savedTeams: savedTeams,
                 picklistTeams: picklistTeams,
-                tournament: inTM ? loadTournament(prefs.getString("TMSavedTournament")) : null,
+                tournament: inTM
+                    ? loadTournament(prefs.getString("TMSavedTournament"))
+                    : null,
               );
             }
 
@@ -508,14 +621,17 @@ class _WorldRankingsState extends State<WorldRankingsScreen> {
 
   List<TeamPreview> _getSavedTeams() {
     final String savedTeam = prefs.getString("savedTeam") ?? "";
-    TeamPreview savedTeamPreview =
-        TeamPreview(teamID: jsonDecode(savedTeam)["teamID"], teamNumber: jsonDecode(savedTeam)["teamNumber"]);
+    TeamPreview savedTeamPreview = TeamPreview(
+        teamID: jsonDecode(savedTeam)["teamID"],
+        teamNumber: jsonDecode(savedTeam)["teamNumber"]);
     List<String> savedTeamsString = prefs.getStringList("savedTeams") ?? [];
 
     List<TeamPreview> savedTeams = [];
     savedTeams.add(savedTeamPreview);
     savedTeams.addAll(savedTeamsString
-        .map((e) => TeamPreview(teamID: jsonDecode(e)["teamID"], teamNumber: jsonDecode(e)["teamNumber"]))
+        .map((e) => TeamPreview(
+            teamID: jsonDecode(e)["teamID"],
+            teamNumber: jsonDecode(e)["teamNumber"]))
         .toList());
     return savedTeams;
   }

--- a/elapse_app/lib/screens/explore/worldRankings/skills/world_skills.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/skills/world_skills.dart
@@ -32,23 +32,34 @@ class WorldSkillsPage extends StatelessWidget {
     List<WorldSkillsStats> teams = rankings.toList();
 
     if (filter.regions!.isNotEmpty) {
-      teams = teams.where((e) => filter.regions!.any((e2) => e2 == (e.eventRegion?.name ?? ""))).toList();
+      teams = teams
+          .where((e) =>
+              filter.regions!.any((e2) => e2 == (e.eventRegion?.name ?? "")))
+          .toList();
     }
 
     if (filter.saved) {
-      teams = teams.where((e) => savedTeams.any((e2) => e2.teamID == e.teamId)).toList();
+      teams = teams
+          .where((e) => savedTeams.any((e2) => e2.teamID == e.teamId))
+          .toList();
     }
 
     if (filter.onPicklist && picklistTeams.isNotEmpty) {
-      teams = teams.where((e) => picklistTeams.any((e2) => e2.teamID == e.teamId)).toList();
+      teams = teams
+          .where((e) => picklistTeams.any((e2) => e2.teamID == e.teamId))
+          .toList();
     }
 
     if (filter.atTournament && tournament != null) {
-      teams = teams.where((e) => tournament!.teams.any((e2) => e2.id == e.teamId)).toList();
+      teams = teams
+          .where((e) => tournament!.teams.any((e2) => e2.id == e.teamId))
+          .toList();
     }
 
     if (filter.scouted) {
-      teams = teams.where((e) => scoutedTeams.any((e2) => e2.teamID == e.teamId)).toList();
+      teams = teams
+          .where((e) => scoutedTeams.any((e2) => e2.teamID == e.teamId))
+          .toList();
     }
 
     if (sort == 0) {
@@ -75,7 +86,9 @@ class WorldSkillsPage extends StatelessWidget {
 
     if (teams.isEmpty) {
       return const SliverToBoxAdapter(
-        child: BigErrorMessage(icon: Icons.sports_esports_outlined, message: "Skills ranking not available"),
+        child: BigErrorMessage(
+            icon: Icons.sports_esports_outlined,
+            message: "Skills ranking not available"),
       );
     }
 

--- a/elapse_app/lib/screens/explore/worldRankings/skills/world_skills_page.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/skills/world_skills_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import '../../../../classes/Team/world_skills.dart';
 import '../../../team_screen/team_screen.dart';
 
-Future<void> worldSkillsPage(
-    BuildContext context, int teamID, String teamNum, String teamName, WorldSkillsStats stats) {
+Future<void> worldSkillsPage(BuildContext context, int teamID, String teamNum,
+    String teamName, WorldSkillsStats stats) {
   final DraggableScrollableController dra = DraggableScrollableController();
 
   return showModalBottomSheet<void>(
@@ -36,26 +36,25 @@ Future<void> worldSkillsPage(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Column(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              "$teamNum Skills",
-                              style: const TextStyle(
-                                fontSize: 24,
-                                height: 1,
-                                fontWeight: FontWeight.w500,
+                            mainAxisAlignment: MainAxisAlignment.spaceAround,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                "$teamNum Skills",
+                                style: const TextStyle(
+                                  fontSize: 24,
+                                  height: 1,
+                                  fontWeight: FontWeight.w500,
+                                ),
                               ),
-                            ),
-                            Text(
-                              teamName,
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w300,
+                              Text(
+                                teamName,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w300,
+                                ),
                               ),
-                            ),
-                          ]
-                        ),
+                            ]),
                         GestureDetector(
                           onTap: () {
                             Navigator.push(
@@ -69,13 +68,12 @@ Future<void> worldSkillsPage(
                             );
                           },
                           child: Text(
-                                "View More",
-                                style: TextStyle(
-                                  fontSize: 16,
-                                  color:
-                                      Theme.of(context).colorScheme.secondary,
-                                ),
-                              ),
+                            "View More",
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Theme.of(context).colorScheme.secondary,
+                            ),
+                          ),
                         )
                       ],
                     ),

--- a/elapse_app/lib/screens/explore/worldRankings/skills/world_skills_widget.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/skills/world_skills_widget.dart
@@ -20,7 +20,8 @@ class WorldSkillsWidget extends StatelessWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () {
-        worldSkillsPage(context, stats.teamId, stats.teamNum, stats.teamName, stats);
+        worldSkillsPage(
+            context, stats.teamId, stats.teamNum, stats.teamName, stats);
       },
       child: Container(
           height: 72,
@@ -35,35 +36,33 @@ class WorldSkillsWidget extends StatelessWidget {
                     flex: 120,
                     child: Row(children: [
                       Flexible(
-                          fit: FlexFit.tight,
-                          flex: 30,
-                          child: Column(
+                        fit: FlexFit.tight,
+                        flex: 30,
+                        child: Column(
                             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(stats.teamNum,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(
-                                  fontSize: 32,
-                                  height: 1,
-                                  letterSpacing: -1.5,
-                                  fontWeight: FontWeight.w400,
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurface)),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                      fontSize: 32,
+                                      height: 1,
+                                      letterSpacing: -1.5,
+                                      fontWeight: FontWeight.w400,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurface)),
                               Text(stats.teamName,
-                                softWrap: false,
-                                overflow: TextOverflow.fade,
+                                  softWrap: false,
+                                  overflow: TextOverflow.fade,
                                   style: TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.w300,
                                       color: Theme.of(context)
                                           .colorScheme
-                                          .onSurfaceVariant)
-                              )
-                            ]
-                          ),
+                                          .onSurfaceVariant))
+                            ]),
                       ),
                       const Spacer(flex: 5),
                       Flexible(

--- a/elapse_app/lib/screens/explore/worldRankings/topWorldSkills.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/topWorldSkills.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../../../classes/Filters/gradeLevel.dart';

--- a/elapse_app/lib/screens/explore/worldRankings/true_skill/world_true_skill.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/true_skill/world_true_skill.dart
@@ -30,19 +30,28 @@ class WorldTrueSkillPage extends StatelessWidget {
     List<VDAStats> teams = stats.where((e) => e.trueSkill != null).toList();
 
     if (filter.regions!.isNotEmpty) {
-      teams = teams.where((e) => filter.regions!.any((e2) => e2 == (e.eventRegion ?? ""))).toList();
+      teams = teams
+          .where(
+              (e) => filter.regions!.any((e2) => e2 == (e.eventRegion ?? "")))
+          .toList();
     }
 
     if (filter.saved) {
-      teams = teams.where((e) => savedTeams.any((e2) => e2.teamID == e.id)).toList();
+      teams = teams
+          .where((e) => savedTeams.any((e2) => e2.teamID == e.id))
+          .toList();
     }
 
     if (filter.onPicklist && picklistTeams.isNotEmpty) {
-      teams = teams.where((e) => picklistTeams.any((e2) => e2.teamID == e.id)).toList();
+      teams = teams
+          .where((e) => picklistTeams.any((e2) => e2.teamID == e.id))
+          .toList();
     }
 
     if (filter.atTournament && tournament != null) {
-      teams = teams.where((e) => tournament!.teams.any((e2) => e2.id == e.id)).toList();
+      teams = teams
+          .where((e) => tournament!.teams.any((e2) => e2.id == e.id))
+          .toList();
     }
 
     if (sort == 0) {
@@ -69,7 +78,9 @@ class WorldTrueSkillPage extends StatelessWidget {
 
     if (teams.isEmpty) {
       return const SliverToBoxAdapter(
-        child: BigErrorMessage(icon: Icons.list_outlined, message: "TrueSkill ranking not available"),
+        child: BigErrorMessage(
+            icon: Icons.list_outlined,
+            message: "TrueSkill ranking not available"),
       );
     }
 

--- a/elapse_app/lib/screens/explore/worldRankings/true_skill/world_true_skill_page.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/true_skill/world_true_skill_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import '../../../../classes/Team/vdaStats.dart';
 import '../../../team_screen/team_screen.dart';
 
-Future<void> worldTrueSkillPage(
-    BuildContext context, int teamID, String teamNum, String teamName, VDAStats stats) {
+Future<void> worldTrueSkillPage(BuildContext context, int teamID,
+    String teamNum, String teamName, VDAStats stats) {
   final DraggableScrollableController dra = DraggableScrollableController();
 
   return showModalBottomSheet<void>(
@@ -36,48 +36,47 @@ Future<void> worldTrueSkillPage(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Column(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              "$teamNum TrueSkill",
-                              style: const TextStyle(
-                                fontSize: 24,
-                                height: 1,
-                                fontWeight: FontWeight.w500,
+                            mainAxisAlignment: MainAxisAlignment.spaceAround,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                "$teamNum TrueSkill",
+                                style: const TextStyle(
+                                  fontSize: 24,
+                                  height: 1,
+                                  fontWeight: FontWeight.w500,
+                                ),
                               ),
-                            ),
-                            Text(
-                              teamName,
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w300,
-                              ),
-                            )
-                          ]
-                        ),
+                              Text(
+                                teamName,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w300,
+                                ),
+                              )
+                            ]),
                         teamID != 0
                             ? GestureDetector(
-                          onTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => TeamScreen(
-                                  teamID: teamID,
-                                  teamNumber: teamNum,
+                                onTap: () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => TeamScreen(
+                                        teamID: teamID,
+                                        teamNumber: teamNum,
+                                      ),
+                                    ),
+                                  );
+                                },
+                                child: Text(
+                                  "View More",
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color:
+                                        Theme.of(context).colorScheme.secondary,
+                                  ),
                                 ),
-                              ),
-                            );
-                          },
-                          child: Text(
-                                "View More",
-                                style: TextStyle(
-                                  fontSize: 16,
-                                  color:
-                                      Theme.of(context).colorScheme.secondary,
-                                ),
-                              ),
-                        )
+                              )
                             : const SizedBox(),
                       ],
                     ),
@@ -122,7 +121,9 @@ Future<void> worldTrueSkillPage(
                           Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text(stats.trueSkill?.toStringAsFixed(1) ?? "N/A",
+                                Text(
+                                    stats.trueSkill?.toStringAsFixed(1) ??
+                                        "N/A",
                                     style: const TextStyle(
                                       fontSize: 24,
                                       fontWeight: FontWeight.w500,
@@ -140,7 +141,8 @@ Future<void> worldTrueSkillPage(
                           Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text("${stats.trueSkillRegionRank == 0 ? "N/A" : stats.trueSkillRegionRank}",
+                                Text(
+                                    "${stats.trueSkillRegionRank == 0 ? "N/A" : stats.trueSkillRegionRank}",
                                     style: const TextStyle(
                                       fontSize: 24,
                                       fontWeight: FontWeight.w500,
@@ -158,7 +160,8 @@ Future<void> worldTrueSkillPage(
                           Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text("${stats.winPercent?.toStringAsFixed(1)} %",
+                                Text(
+                                    "${stats.winPercent?.toStringAsFixed(1)} %",
                                     style: const TextStyle(
                                       fontSize: 24,
                                       fontWeight: FontWeight.w500,

--- a/elapse_app/lib/screens/explore/worldRankings/true_skill/world_true_skill_widget.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/true_skill/world_true_skill_widget.dart
@@ -20,7 +20,8 @@ class WorldTrueSkillWidget extends StatelessWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () {
-        worldTrueSkillPage(context, stats.id, stats.teamNum, stats.teamName!, stats);
+        worldTrueSkillPage(
+            context, stats.id, stats.teamNum, stats.teamName!, stats);
       },
       child: Container(
           height: 72,
@@ -38,32 +39,30 @@ class WorldTrueSkillWidget extends StatelessWidget {
                           fit: FlexFit.tight,
                           flex: 30,
                           child: Column(
-                            mainAxisAlignment: MainAxisAlignment.spaceAround,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(stats.teamNum,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                      fontSize: 32,
-                                      height: 1,
-                                      letterSpacing: -1.5,
-                                      fontWeight: FontWeight.w400,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onSurface)),
-                              Text(stats.teamName!,
-                                softWrap: false,
-                                overflow: TextOverflow.fade,
-                                style: TextStyle(
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w300,
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurfaceVariant)
-                              )
-                            ]
-                          )),
+                              mainAxisAlignment: MainAxisAlignment.spaceAround,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(stats.teamNum,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                        fontSize: 32,
+                                        height: 1,
+                                        letterSpacing: -1.5,
+                                        fontWeight: FontWeight.w400,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface)),
+                                Text(stats.teamName!,
+                                    softWrap: false,
+                                    overflow: TextOverflow.fade,
+                                    style: TextStyle(
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.w300,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurfaceVariant))
+                              ])),
                       const Spacer(flex: 5),
                       Flexible(
                         flex: 15,

--- a/elapse_app/lib/screens/explore/worldRankings/world_rankings_filter.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/world_rankings_filter.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../../classes/Filters/region.dart';
-import '../../../classes/Team/vdaStats.dart';
-import '../../../classes/Team/world_skills.dart';
 
 class WorldRankingsFilter {
   List<String>? regions;
@@ -17,14 +15,11 @@ class WorldRankingsFilter {
     this.onPicklist = false,
     this.atTournament = false,
     this.scouted = false,
-  }) : this.regions = regions ?? [];
+  }) : regions = regions ?? [];
 }
 
-Future<WorldRankingsFilter> worldRankingsFilter(
-    BuildContext context,
-    WorldRankingsFilter filter,
-    bool isInTM,
-    List<String> regions) async {
+Future<WorldRankingsFilter> worldRankingsFilter(BuildContext context,
+    WorldRankingsFilter filter, bool isInTM, List<String> regions) async {
   final DraggableScrollableController dra = DraggableScrollableController();
 
   bool inTM = isInTM;

--- a/elapse_app/lib/screens/explore/worldRankings/world_rankings_search_screen.dart
+++ b/elapse_app/lib/screens/explore/worldRankings/world_rankings_search_screen.dart
@@ -17,7 +17,8 @@ class WorldRankingsSearchScreen extends StatefulWidget {
   final List<VDAStats> vda;
 
   @override
-  State<WorldRankingsSearchScreen> createState() => _WorldRankingsSearchScreenState();
+  State<WorldRankingsSearchScreen> createState() =>
+      _WorldRankingsSearchScreenState();
 }
 
 class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
@@ -47,7 +48,9 @@ class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
           e.teamNum.toLowerCase().contains(searchQuery.toLowerCase()));
     }).toList();
     List<VDAStats> filteredVDA = widget.vda.where((e) {
-      return ((e.teamName ?? "").toLowerCase().contains(searchQuery.toLowerCase()) ||
+      return ((e.teamName ?? "")
+              .toLowerCase()
+              .contains(searchQuery.toLowerCase()) ||
           e.teamNum.toLowerCase().contains(searchQuery.toLowerCase()));
     }).toList();
 
@@ -82,12 +85,14 @@ class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
                               const Spacer(),
                               Flex(
                                   direction: Axis.horizontal,
-                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
                                   children: [
                                     Flexible(
                                       flex: 1,
                                       child: IconButton(
-                                        icon: const Icon(Icons.arrow_back, size: 24),
+                                        icon: const Icon(Icons.arrow_back,
+                                            size: 24),
                                         onPressed: () => Navigator.pop(context),
                                       ),
                                     ),
@@ -100,7 +105,9 @@ class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
                                               searchQuery = value;
                                             });
                                           },
-                                          cursorColor: Theme.of(context).colorScheme.secondary,
+                                          cursorColor: Theme.of(context)
+                                              .colorScheme
+                                              .secondary,
                                           decoration: const InputDecoration(
                                             hintText: "Search world rankings",
                                             border: InputBorder.none,
@@ -110,21 +117,32 @@ class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
                               const Spacer(),
                               if (constraints.maxHeight - 135 + 45 > 0)
                                 SizedBox(
-                                    height: containerHeight > 130 ? 45 : containerHeight - 130 + 45,
-                                    child: Flex(direction: Axis.horizontal, children: [
-                                      Flexible(
-                                        flex: 1,
-                                        child: _filterButton(0, constraints.maxHeight, "All"),
-                                      ),
-                                      Flexible(
-                                        flex: 1,
-                                        child: _filterButton(1, constraints.maxHeight, "Skills"),
-                                      ),
-                                      Flexible(
-                                        flex: 1,
-                                        child: _filterButton(2, constraints.maxHeight, "TrueSkill"),
-                                      ),
-                                    ]))
+                                    height: containerHeight > 130
+                                        ? 45
+                                        : containerHeight - 130 + 45,
+                                    child: Flex(
+                                        direction: Axis.horizontal,
+                                        children: [
+                                          Flexible(
+                                            flex: 1,
+                                            child: _filterButton(0,
+                                                constraints.maxHeight, "All"),
+                                          ),
+                                          Flexible(
+                                            flex: 1,
+                                            child: _filterButton(
+                                                1,
+                                                constraints.maxHeight,
+                                                "Skills"),
+                                          ),
+                                          Flexible(
+                                            flex: 1,
+                                            child: _filterButton(
+                                                2,
+                                                constraints.maxHeight,
+                                                "TrueSkill"),
+                                          ),
+                                        ]))
                               else
                                 const Spacer(),
                               const Spacer(),
@@ -198,7 +216,9 @@ class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
                             index != filteredSkills.length - 1
                                 ? Divider(
                                     height: 3,
-                                    color: Theme.of(context).colorScheme.surfaceDim,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceDim,
                                   )
                                 : Container(),
                           ],
@@ -246,7 +266,9 @@ class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
                             index != filteredVDA.length - 1
                                 ? Divider(
                                     height: 3,
-                                    color: Theme.of(context).colorScheme.surfaceDim,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceDim,
                                   )
                                 : Container(),
                           ],
@@ -290,38 +312,41 @@ class _WorldRankingsSearchScreenState extends State<WorldRankingsSearchScreen> {
       },
       child: AnimatedContainer(
         curve: Curves.fastOutSlowIn,
-        duration: const Duration(milliseconds: 300), // Duration of the animation
+        duration:
+            const Duration(milliseconds: 300), // Duration of the animation
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: selectedIndex == buttonIndex
-              ? selectedContainerColor.withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)
-              : unselectedContainerColor.withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+              ? selectedContainerColor.withValues(
+                  alpha:
+                      ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)
+              : unselectedContainerColor.withValues(
+                  alpha:
+                      ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
           border: buttonIndex == 1
               ? Border.symmetric(
                   horizontal: BorderSide(
                     width: 1.5,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .primary
-                        .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+                    color: Theme.of(context).colorScheme.primary.withValues(
+                        alpha: ((maxHeight - 85) / 40) > 1
+                            ? 1
+                            : (maxHeight - 85) / 40),
                   ),
                 )
               : Border.all(
                   width: 1.5,
-                  color: Theme.of(context)
-                      .colorScheme
-                      .primary
-                      .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+                  color: Theme.of(context).colorScheme.primary.withValues(
+                      alpha: ((maxHeight - 85) / 40) > 1
+                          ? 1
+                          : (maxHeight - 85) / 40),
                 ),
           borderRadius: borderRadius,
         ),
         child: Text(
           text,
           style: TextStyle(
-            color: Theme.of(context)
-                .colorScheme
-                .secondary
-                .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+            color: Theme.of(context).colorScheme.secondary.withValues(
+                alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
             fontSize: 14,
             fontWeight: FontWeight.w500,
           ),

--- a/elapse_app/lib/screens/my_team/my_team.dart
+++ b/elapse_app/lib/screens/my_team/my_team.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:elapse_app/aesthetics/color_pallete.dart';
-import 'package:elapse_app/aesthetics/color_schemes.dart';
 import 'package:elapse_app/classes/Miscellaneous/location.dart';
 import 'package:elapse_app/classes/Team/team.dart';
 import 'package:elapse_app/classes/Team/teamPreview.dart';
@@ -45,12 +43,15 @@ class _MyTeamsState extends State<MyTeams> {
   void reload() {
     final String savedTeam = prefs.getString("savedTeam") ?? "";
     final parsed = jsonDecode(savedTeam);
-    savedTeamPreview = TeamPreview(teamID: parsed["teamID"], teamNumber: parsed["teamNumber"]);
+    savedTeamPreview =
+        TeamPreview(teamID: parsed["teamID"], teamNumber: parsed["teamNumber"]);
 
     savedTeamStrings = prefs.getStringList("savedTeams") ?? [];
     savedTeamPreviews.add(savedTeamPreview);
     savedTeamPreviews.addAll(savedTeamStrings
-        .map((e) => TeamPreview(teamID: jsonDecode(e)["teamID"], teamNumber: jsonDecode(e)["teamNumber"]))
+        .map((e) => TeamPreview(
+            teamID: jsonDecode(e)["teamID"],
+            teamNumber: jsonDecode(e)["teamNumber"]))
         .toList());
 
     selectedTeamPreview = savedTeamPreview;
@@ -58,9 +59,11 @@ class _MyTeamsState extends State<MyTeams> {
     savedTeamPreviews = savedTeamPreviews.toSet().toList();
     season = seasons[0];
     team = fetchTeam(savedTeamPreview.teamID);
-    teamStats = getTrueSkillDataForTeam(season.vrcId, savedTeamPreview.teamNumber);
+    teamStats =
+        getTrueSkillDataForTeam(season.vrcId, savedTeamPreview.teamNumber);
     skillsStats = getWorldSkillsForTeam(season.vrcId, savedTeamPreview.teamID);
-    teamTournaments = fetchTeamTournaments(savedTeamPreview.teamID, season.vrcId);
+    teamTournaments =
+        fetchTeamTournaments(savedTeamPreview.teamID, season.vrcId);
     teamAwards = getAwards(savedTeamPreview.teamID, season.vrcId);
   }
 
@@ -72,12 +75,6 @@ class _MyTeamsState extends State<MyTeams> {
 
   @override
   Widget build(BuildContext context) {
-    ColorPallete colorPallete;
-    if (Theme.of(context).colorScheme.brightness == Brightness.dark) {
-      colorPallete = darkPallete;
-    } else {
-      colorPallete = lightPallete;
-    }
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: CustomScrollView(
@@ -101,28 +98,35 @@ class _MyTeamsState extends State<MyTeams> {
                           Season updated = await Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (context) => SeasonFilterPage(selected: season),
+                              builder: (context) =>
+                                  SeasonFilterPage(selected: season),
                             ),
                           );
                           setState(() {
                             season = updated;
-                            skillsStats = getWorldSkillsForTeam(season.vrcId, savedTeamPreview.teamID);
-                            teamStats = getTrueSkillDataForTeam(season.vrcId, savedTeamPreview.teamNumber);
-                            teamTournaments = fetchTeamTournaments(savedTeamPreview.teamID, season.vrcId);
-                            teamAwards = getAwards(savedTeamPreview.teamID, season.vrcId);
+                            skillsStats = getWorldSkillsForTeam(
+                                season.vrcId, savedTeamPreview.teamID);
+                            teamStats = getTrueSkillDataForTeam(
+                                season.vrcId, savedTeamPreview.teamNumber);
+                            teamTournaments = fetchTeamTournaments(
+                                savedTeamPreview.teamID, season.vrcId);
+                            teamAwards = getAwards(
+                                savedTeamPreview.teamID, season.vrcId);
                           });
                         },
                         child: Padding(
                           padding: const EdgeInsets.only(top: 10.0),
-                          child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                            const Icon(Icons.event_note),
-                            const SizedBox(width: 4),
-                            Text(
-                              season.name.substring(10),
-                              style: const TextStyle(fontSize: 16),
-                            ),
-                            const Icon(Icons.arrow_right)
-                          ]),
+                          child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Icon(Icons.event_note),
+                                const SizedBox(width: 4),
+                                Text(
+                                  season.name.substring(10),
+                                  style: const TextStyle(fontSize: 16),
+                                ),
+                                const Icon(Icons.arrow_right)
+                              ]),
                         )),
                     const Spacer(),
                     SettingsButton(callback: () {
@@ -141,8 +145,10 @@ class _MyTeamsState extends State<MyTeams> {
             sliver: SliverToBoxAdapter(
               child: Container(
                 decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(18), color: Theme.of(context).colorScheme.tertiary),
-                padding: const EdgeInsets.only(left: 18, right: 18, bottom: 18, top: 18),
+                    borderRadius: BorderRadius.circular(18),
+                    color: Theme.of(context).colorScheme.tertiary),
+                padding: const EdgeInsets.only(
+                    left: 18, right: 18, bottom: 18, top: 18),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -181,7 +187,9 @@ class _MyTeamsState extends State<MyTeams> {
                                       style: TextStyle(fontSize: 24),
                                     ),
                                     const Spacer(),
-                                    Container(width: 75, child: const LinearProgressIndicator()),
+                                    SizedBox(
+                                        width: 75,
+                                        child: const LinearProgressIndicator()),
                                   ],
                                 ),
                                 const SizedBox(
@@ -194,7 +202,9 @@ class _MyTeamsState extends State<MyTeams> {
                                       style: TextStyle(fontSize: 24),
                                     ),
                                     const Spacer(),
-                                    Container(width: 75, child: const LinearProgressIndicator()),
+                                    SizedBox(
+                                        width: 75,
+                                        child: const LinearProgressIndicator()),
                                   ],
                                 ),
                               ],
@@ -233,7 +243,9 @@ class _MyTeamsState extends State<MyTeams> {
                                     const Spacer(),
                                     Text(
                                       qualificationString,
-                                      style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.w500),
                                     ),
                                   ],
                                 ),
@@ -249,7 +261,9 @@ class _MyTeamsState extends State<MyTeams> {
                                     const Spacer(),
                                     Text(
                                       "${stats.winPercent == null ? "" : stats.winPercent!.toStringAsFixed(1)}%",
-                                      style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.w500),
                                     ),
                                   ],
                                 ),
@@ -286,7 +300,11 @@ class _MyTeamsState extends State<MyTeams> {
                             organization: "",
                           );
                         } else {
-                          return TeamBio(grade: "", location: Location(), teamName: "", organization: "");
+                          return TeamBio(
+                              grade: "",
+                              location: Location(),
+                              teamName: "",
+                              organization: "");
                         }
                       },
                     )
@@ -330,13 +348,15 @@ class _MyTeamsState extends State<MyTeams> {
                             return const Text("Skills Data Unavailable");
                           }
 
-                          WorldSkillsStats stats = snapshot.data as WorldSkillsStats;
+                          WorldSkillsStats stats =
+                              snapshot.data as WorldSkillsStats;
                           return Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
                                 stats.rank.toString(),
-                                style: const TextStyle(fontSize: 64, height: 1, letterSpacing: -2),
+                                style: const TextStyle(
+                                    fontSize: 64, height: 1, letterSpacing: -2),
                               ),
                               const SizedBox(
                                 height: 5,
@@ -351,39 +371,51 @@ class _MyTeamsState extends State<MyTeams> {
                               Row(
                                 children: [
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.score.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("Score", style: TextStyle(fontSize: 16))
+                                      const Text("Score",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   ),
                                   const SizedBox(
                                     width: 18,
                                   ),
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.driver.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("Driver", style: TextStyle(fontSize: 16))
+                                      const Text("Driver",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   ),
                                   const SizedBox(
                                     width: 18,
                                   ),
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.auton.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("Auto", style: TextStyle(fontSize: 16))
+                                      const Text("Auto",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   )
                                 ],
@@ -446,7 +478,8 @@ class _MyTeamsState extends State<MyTeams> {
                             children: [
                               Text(
                                 stats.trueSkillGlobalRank.toString(),
-                                style: const TextStyle(fontSize: 64, height: 1, letterSpacing: -2),
+                                style: const TextStyle(
+                                    fontSize: 64, height: 1, letterSpacing: -2),
                               ),
                               const SizedBox(
                                 height: 5,
@@ -461,26 +494,34 @@ class _MyTeamsState extends State<MyTeams> {
                               Row(
                                 children: [
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.trueSkill.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("Score", style: TextStyle(fontSize: 16))
+                                      const Text("Score",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   ),
                                   const SizedBox(
                                     width: 18,
                                   ),
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.trueSkillRegionRank.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("Region Rank", style: TextStyle(fontSize: 16))
+                                      const Text("Region Rank",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   ),
                                   const SizedBox(
@@ -494,39 +535,51 @@ class _MyTeamsState extends State<MyTeams> {
                               Row(
                                 children: [
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.opr.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("OPR", style: TextStyle(fontSize: 16))
+                                      const Text("OPR",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   ),
                                   const SizedBox(
                                     width: 18,
                                   ),
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.dpr.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("DPR", style: TextStyle(fontSize: 16))
+                                      const Text("DPR",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   ),
                                   const SizedBox(
                                     width: 18,
                                   ),
                                   Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         stats.ccwm.toString(),
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
-                                      const Text("CCWM", style: TextStyle(fontSize: 16))
+                                      const Text("CCWM",
+                                          style: TextStyle(fontSize: 16))
                                     ],
                                   ),
                                 ],
@@ -541,7 +594,7 @@ class _MyTeamsState extends State<MyTeams> {
             ),
           ),
           const SliverToBoxAdapter(
-            child: const SizedBox(
+            child: SizedBox(
               height: 28,
             ),
           ),
@@ -595,9 +648,12 @@ class _MyTeamsState extends State<MyTeams> {
                                   children: [
                                     Text(
                                       stats.wins.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Wins", style: TextStyle(fontSize: 16))
+                                    const Text("Wins",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(width: 18),
@@ -606,9 +662,12 @@ class _MyTeamsState extends State<MyTeams> {
                                   children: [
                                     Text(
                                       stats.losses.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Losses", style: TextStyle(fontSize: 16))
+                                    const Text("Losses",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(width: 18),
@@ -617,9 +676,12 @@ class _MyTeamsState extends State<MyTeams> {
                                   children: [
                                     Text(
                                       stats.ties.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Ties", style: TextStyle(fontSize: 16))
+                                    const Text("Ties",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(width: 18),
@@ -628,9 +690,12 @@ class _MyTeamsState extends State<MyTeams> {
                                   children: [
                                     Text(
                                       stats.matches.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Matches", style: TextStyle(fontSize: 16))
+                                    const Text("Matches",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(width: 18),
@@ -686,11 +751,15 @@ class _MyTeamsState extends State<MyTeams> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
-                                  const Text("Awards", style: TextStyle(fontSize: 24)),
+                                  const Text("Awards",
+                                      style: TextStyle(fontSize: 24)),
                                   Text(awards.length.toString(),
-                                      style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500))
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.w500))
                                 ],
                               ),
                               const SizedBox(height: 18),
@@ -702,28 +771,35 @@ class _MyTeamsState extends State<MyTeams> {
                                         alignment: Alignment.centerLeft,
                                         height: 60,
                                         child: Column(
-                                          crossAxisAlignment: CrossAxisAlignment.start,
-                                          mainAxisAlignment: MainAxisAlignment.center,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
                                           children: [
                                             Text(
                                               e.name,
                                               overflow: TextOverflow.ellipsis,
                                               textAlign: TextAlign.start,
                                               maxLines: 1,
-                                              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                              style: const TextStyle(
+                                                  fontSize: 16,
+                                                  fontWeight: FontWeight.w500),
                                             ),
                                             Text(
                                               maxLines: 1,
                                               overflow: TextOverflow.ellipsis,
                                               textAlign: TextAlign.start,
                                               e.tournamentName ?? "",
-                                              style: const TextStyle(fontSize: 16),
+                                              style:
+                                                  const TextStyle(fontSize: 16),
                                             )
                                           ],
                                         ),
                                       ),
                                       Divider(
-                                        color: Theme.of(context).colorScheme.surfaceDim,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceDim,
                                       )
                                     ],
                                   );
@@ -777,11 +853,13 @@ class _MyTeamsState extends State<MyTeams> {
                             return const Text("Tournaments Unavailable");
                           }
 
-                          List<TournamentPreview> tournaments = snapshot.data as List<TournamentPreview>;
+                          List<TournamentPreview> tournaments =
+                              snapshot.data as List<TournamentPreview>;
                           return Column(
                             children: tournaments
                                 .map(
-                                  (e) => TournamentPreviewWidget(tournamentPreview: e),
+                                  (e) => TournamentPreviewWidget(
+                                      tournamentPreview: e),
                                 )
                                 .toList(),
                           );
@@ -829,21 +907,21 @@ class TeamBio extends StatelessWidget {
                 children: [
                   SizedBox(
                     height: 24,
-                    child: 
-                    Align(
+                    child: Align(
                       alignment: Alignment.bottomLeft,
                       child: Text(
                         teamName,
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                        style: const TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.w600),
                         textAlign: TextAlign.left,
-                    ),
+                      ),
                     ),
                   ),
                   const Text(
                     "Team Name",
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                     ),
                   ),
@@ -859,21 +937,21 @@ class TeamBio extends StatelessWidget {
                 children: [
                   SizedBox(
                     height: 24,
-                    child: 
-                    Align(
+                    child: Align(
                       alignment: Alignment.bottomRight,
                       child: Text(
                         getGrade(grade),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                        style: const TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.w600),
                         textAlign: TextAlign.right,
                       ),
                     ),
                   ),
                   const Text(
                     "Grade",
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                     ),
                     textAlign: TextAlign.right,
@@ -900,19 +978,19 @@ class TeamBio extends StatelessWidget {
                     height: 48,
                     child: Align(
                       alignment: Alignment.bottomLeft,
-                      child: 
-                      Text(
+                      child: Text(
                         getLocation(location),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                        style: const TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.w600),
                         textAlign: TextAlign.left,
                       ),
                     ),
                   ),
                   const Text(
                     "Location",
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                     ),
                   ),
@@ -934,14 +1012,15 @@ class TeamBio extends StatelessWidget {
                         organization,
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                        style: const TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.w600),
                         textAlign: TextAlign.right,
                       ),
                     ),
                   ),
                   const Text(
                     "Organization",
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                     ),
                     textAlign: TextAlign.right,

--- a/elapse_app/lib/screens/scout/cloud_scout.dart
+++ b/elapse_app/lib/screens/scout/cloud_scout.dart
@@ -2,7 +2,6 @@ import 'package:elapse_app/classes/Team/teamPreview.dart';
 import 'package:elapse_app/main.dart';
 import 'package:elapse_app/screens/widgets/app_bar.dart';
 import 'package:elapse_app/screens/widgets/big_error_message.dart';
-import 'package:elapse_app/screens/widgets/long_button.dart';
 import 'package:elapse_app/screens/widgets/rounded_top.dart';
 import 'package:elapse_app/screens/widgets/team_widget.dart';
 import 'package:flutter/material.dart';
@@ -19,47 +18,19 @@ class CloudScoutScreen extends StatefulWidget {
 class _CloudScoutScreenState extends State<CloudScoutScreen> {
   @override
   Widget build(BuildContext context) {
-    bool teamSync = true;
     List<String> savedTeams = prefs.getStringList("savedTeams") ?? [];
-    List<TeamPreview> savedTeamPreview = savedTeams.map((e) => loadTeamPreview(e)).toList();
+    List<TeamPreview> savedTeamPreview =
+        savedTeams.map((e) => loadTeamPreview(e)).toList();
     return Scaffold(
       body: CustomScrollView(
         slivers: [
           ElapseAppBar(
-            title: Text("CloudScout", style: TextStyle(fontSize: 24, fontWeight: FontWeight.w600)),
+            title: Text("CloudScout",
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.w600)),
             includeSettings: true,
             settingsCallback: () => setState(() {}),
           ),
           RoundedTop(),
-          !teamSync
-              ? SliverToBoxAdapter(
-                  child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 23),
-                  child: Container(
-                    padding: EdgeInsets.all(18),
-                    margin: EdgeInsets.only(bottom: 12),
-                    decoration: BoxDecoration(
-                        border: Border.all(width: 1, color: Theme.of(context).colorScheme.primary),
-                        borderRadius: BorderRadius.circular(18)),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          "TeamSync",
-                          style: TextStyle(fontSize: 24),
-                        ),
-                        SizedBox(height: 18),
-                        Text(
-                          "Sync your ScoutSheets with your teammates.",
-                          style: TextStyle(fontSize: 16, fontWeight: FontWeight.w300),
-                        ),
-                        SizedBox(height: 24),
-                        LongButton(onPressed: () {}, gradient: true, text: "Sync Team Data", icon: Icons.sync),
-                      ],
-                    ),
-                  ),
-                ))
-              : SliverToBoxAdapter(),
           SliverToBoxAdapter(
             child: prefs.getBool("isTournamentMode") ?? false
                 ? Column(children: [
@@ -78,7 +49,10 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
                         ),
                         child: InkWell(
                           borderRadius: BorderRadius.circular(18),
-                          splashColor: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.05),
+                          splashColor: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.05),
                           onTap: () {
                             Navigator.push(
                                 context,
@@ -94,7 +68,8 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
                                 children: [
                                   Icon(
                                     Icons.list_alt_outlined,
-                                    color: Theme.of(context).colorScheme.secondary,
+                                    color:
+                                        Theme.of(context).colorScheme.secondary,
                                   ),
                                   SizedBox(width: 12),
                                   Text("My Picklist")
@@ -123,7 +98,8 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
           savedTeams.isEmpty
               ? SliverToBoxAdapter(
                   child: BigErrorMessage(
-                      icon: Icons.bookmark_add_outlined, message: "Add some teams from the explore menu"),
+                      icon: Icons.bookmark_add_outlined,
+                      message: "Add some teams from the explore menu"),
                 )
               : SliverPadding(
                   padding: EdgeInsets.symmetric(horizontal: 23),

--- a/elapse_app/lib/screens/team_screen/camera/photo_bottom_sheet.dart
+++ b/elapse_app/lib/screens/team_screen/camera/photo_bottom_sheet.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:elapse_app/aesthetics/color_schemes.dart';
 import 'package:elapse_app/screens/widgets/long_button.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -10,9 +9,6 @@ import 'package:path/path.dart' as p;
 const int maxFileSize = 5 * 1024 * 1024; // 5 MB
 
 Future<String?> getPhoto(BuildContext context) async {
-  Color redColor =
-      Theme.of(context).brightness == Brightness.light ? lightPallete.redAllianceText : darkPallete.redAllianceText;
-
   File? image;
   XFile? imageData;
   String? imageURL;
@@ -69,7 +65,9 @@ Future<String?> getPhoto(BuildContext context) async {
                                             height: 36,
                                             width: 36,
                                             decoration: BoxDecoration(
-                                                shape: BoxShape.circle, color: Colors.black.withValues(alpha: 0.5)),
+                                                shape: BoxShape.circle,
+                                                color: Colors.black
+                                                    .withValues(alpha: 0.5)),
                                           ),
                                           IconButton(
                                             onPressed: () {
@@ -95,13 +93,18 @@ Future<String?> getPhoto(BuildContext context) async {
                                   children: [
                                     TextButton.icon(
                                       style: TextButton.styleFrom(
-                                        foregroundColor: Theme.of(context).colorScheme.secondary,
+                                        foregroundColor: Theme.of(context)
+                                            .colorScheme
+                                            .secondary,
                                         shape: RoundedRectangleBorder(
                                           side: BorderSide(
-                                            color: Theme.of(context).colorScheme.primary,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .primary,
                                             width: 2,
                                           ),
-                                          borderRadius: BorderRadius.circular(30),
+                                          borderRadius:
+                                              BorderRadius.circular(30),
                                         ),
                                       ),
                                       onPressed: () async {
@@ -110,7 +113,8 @@ Future<String?> getPhoto(BuildContext context) async {
                                           builder: (context) {
                                             return AlertDialog(
                                               title: Text("Uploading Photo"),
-                                              content: Text("You will be navigated back once the photo is uploaded"),
+                                              content: Text(
+                                                  "You will be navigated back once the photo is uploaded"),
                                             );
                                           },
                                         );
@@ -129,9 +133,11 @@ Future<String?> getPhoto(BuildContext context) async {
                       SizedBox(height: 36),
                       LongButton(
                         onPressed: () async {
-                          final returnedImage = await ImagePicker().pickImage(source: ImageSource.camera);
+                          final returnedImage = await ImagePicker()
+                              .pickImage(source: ImageSource.camera);
                           if (returnedImage != null) {
-                            if (await File(returnedImage.path).length() <= maxFileSize) {
+                            if (await File(returnedImage.path).length() <=
+                                maxFileSize) {
                               setState(() {
                                 imageData = returnedImage;
                                 image = File(returnedImage.path);
@@ -147,9 +153,11 @@ Future<String?> getPhoto(BuildContext context) async {
                       SizedBox(height: 18),
                       LongButton(
                         onPressed: () async {
-                          final returnedImage = await ImagePicker().pickImage(source: ImageSource.gallery);
+                          final returnedImage = await ImagePicker()
+                              .pickImage(source: ImageSource.gallery);
                           if (returnedImage != null) {
-                            if (await File(returnedImage.path).length() <= maxFileSize) {
+                            if (await File(returnedImage.path).length() <=
+                                maxFileSize) {
                               setState(() {
                                 imageData = returnedImage;
                                 image = File(returnedImage.path);
@@ -186,12 +194,13 @@ void _showSizeError(BuildContext context) {
 }
 
 Future<String?> uploadFile(XFile? pic) async {
-  final path = 'images/${FirebaseAuth.instance.currentUser?.uid}/scoutsheet/images/${pic!.name}';
+  final path =
+      'images/${FirebaseAuth.instance.currentUser?.uid}/scoutsheet/images/${pic!.name}';
   final file = File(pic.path);
 
   final ref = FirebaseStorage.instance.ref().child(path);
-  final snapshot = await ref.putData(
-      file.readAsBytesSync(), SettableMetadata(contentType: 'image/${p.extension(path).substring(1)}'));
+  final snapshot = await ref.putData(file.readAsBytesSync(),
+      SettableMetadata(contentType: 'image/${p.extension(path).substring(1)}'));
 
   return await snapshot.ref.getDownloadURL();
 

--- a/elapse_app/lib/screens/team_screen/details/details.dart
+++ b/elapse_app/lib/screens/team_screen/details/details.dart
@@ -11,7 +11,6 @@ import 'package:elapse_app/classes/Tournament/tournament_preview.dart';
 import 'package:elapse_app/main.dart';
 import 'package:elapse_app/screens/my_team/my_team.dart';
 import 'package:elapse_app/screens/tournament_mode/picklist/picklist.dart';
-import 'package:elapse_app/screens/tournament_mode/picklist/picklist_widget.dart';
 import 'package:elapse_app/screens/widgets/tournament_preview_widget.dart';
 import 'package:flutter/material.dart';
 
@@ -37,9 +36,11 @@ List<Widget> Details(
       padding: const EdgeInsets.symmetric(horizontal: 23),
       sliver: SliverToBoxAdapter(
         child: Container(
-          decoration:
-              BoxDecoration(borderRadius: BorderRadius.circular(18), color: Theme.of(context).colorScheme.tertiary),
-          padding: const EdgeInsets.only(left: 18, right: 18, bottom: 18, top: 18),
+          decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(18),
+              color: Theme.of(context).colorScheme.tertiary),
+          padding:
+              const EdgeInsets.only(left: 18, right: 18, bottom: 18, top: 18),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -48,16 +49,20 @@ List<Widget> Details(
                 children: [
                   Text(
                     teamNumber,
-                    style: const TextStyle(fontSize: 64, height: 1, letterSpacing: -2),
+                    style: const TextStyle(
+                        fontSize: 64, height: 1, letterSpacing: -2),
                   ),
                   displaySave
                       ? IconButton(
                           focusColor: Colors.transparent,
                           highlightColor: Colors.transparent,
-                          padding: EdgeInsets.only(left: 10, top: 10, bottom: 10),
+                          padding:
+                              EdgeInsets.only(left: 10, top: 10, bottom: 10),
                           constraints: BoxConstraints(),
                           icon: Icon(
-                            isSaved ? Icons.bookmark_rounded : Icons.bookmark_add_outlined,
+                            isSaved
+                                ? Icons.bookmark_rounded
+                                : Icons.bookmark_add_outlined,
                             size: 36,
                           ),
                           onPressed: toggleSaveTeam)
@@ -90,7 +95,8 @@ List<Widget> Details(
                                 style: TextStyle(fontSize: 24),
                               ),
                               const Spacer(),
-                              Container(width: 75, child: LinearProgressIndicator()),
+                              SizedBox(
+                                  width: 75, child: LinearProgressIndicator()),
                             ],
                           ),
                           const SizedBox(
@@ -103,7 +109,8 @@ List<Widget> Details(
                                 style: TextStyle(fontSize: 24),
                               ),
                               const Spacer(),
-                              Container(width: 75, child: LinearProgressIndicator()),
+                              SizedBox(
+                                  width: 75, child: LinearProgressIndicator()),
                             ],
                           ),
                         ],
@@ -142,7 +149,8 @@ List<Widget> Details(
                               Spacer(),
                               Text(
                                 qualificationString,
-                                style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 24, fontWeight: FontWeight.w500),
                               ),
                             ],
                           ),
@@ -158,7 +166,8 @@ List<Widget> Details(
                               Spacer(),
                               Text(
                                 "${stats.winPercent == null ? "" : stats.winPercent!.toStringAsFixed(1)}%",
-                                style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 24, fontWeight: FontWeight.w500),
                               ),
                             ],
                           ),
@@ -196,7 +205,11 @@ List<Widget> Details(
                             organization: "",
                           );
                         } else {
-                          return TeamBio(grade: "", location: Location(), teamName: "", organization: "");
+                          return TeamBio(
+                              grade: "",
+                              location: Location(),
+                              teamName: "",
+                              organization: "");
                         }
                       },
                     )
@@ -225,14 +238,18 @@ List<Widget> Details(
                 case ConnectionState.active:
                   return const SliverToBoxAdapter(
                     child: Padding(
-                        padding: EdgeInsets.only(bottom: 28), child: Center(child: CircularProgressIndicator())),
+                        padding: EdgeInsets.only(bottom: 28),
+                        child: Center(child: CircularProgressIndicator())),
                   );
                 case ConnectionState.done:
                   if (snapshot.hasError) {
                     return const SliverToBoxAdapter(child: SizedBox.shrink());
                   }
 
-                  if ((snapshot.data as Tournament).teams.firstWhereOrNull((e) => e.id == teamSave.teamID) == null) {
+                  if ((snapshot.data as Tournament)
+                          .teams
+                          .firstWhereOrNull((e) => e.id == teamSave.teamID) ==
+                      null) {
                     return const SliverToBoxAdapter(child: SizedBox.shrink());
                   }
 
@@ -240,13 +257,16 @@ List<Widget> Details(
                       child: Column(children: [
                     GestureDetector(
                         onTap: () {
-                          List<String> picklist = prefs.getStringList("picklist") ?? [];
-                          if ((prefs.getStringList("picklist") ?? []).contains(jsonEncode(teamSave.toJson()))) {
+                          List<String> picklist =
+                              prefs.getStringList("picklist") ?? [];
+                          if ((prefs.getStringList("picklist") ?? [])
+                              .contains(jsonEncode(teamSave.toJson()))) {
                             picklist.remove(jsonEncode(teamSave.toJson()));
                           } else {
                             picklist.add(jsonEncode(teamSave.toJson()));
                           }
-                          prefs.setStringList("picklist", picklist.toSet().toList());
+                          prefs.setStringList(
+                              "picklist", picklist.toSet().toList());
                           setState;
                         },
                         onDoubleTap: () async {
@@ -264,35 +284,52 @@ List<Widget> Details(
                                   color: Theme.of(context).colorScheme.tertiary,
                                   borderRadius: BorderRadius.circular(18),
                                   border: Border.all(
-                                    color: Theme.of(context).colorScheme.tertiary,
+                                    color:
+                                        Theme.of(context).colorScheme.tertiary,
                                     width: 2,
                                   ),
                                 ),
-                                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 21),
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 24, vertical: 21),
                                 child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                    crossAxisAlignment: CrossAxisAlignment.center,
-                                    children:
-                                        (prefs.getStringList("picklist") ?? []).contains(jsonEncode(teamSave.toJson()))
-                                            ? [
-                                                Text(
-                                                    "Rank ${prefs.getStringList("picklist")!.indexOf(jsonEncode(teamSave.toJson())) + 1} on Picklist",
-                                                    style: TextStyle(
-                                                      fontSize: 18,
-                                                      color: Theme.of(context).colorScheme.onSurface,
-                                                    )),
-                                                Icon(Icons.playlist_add_check,
-                                                    color: Theme.of(context).colorScheme.secondary, size: 24),
-                                              ]
-                                            : [
-                                                Text("Add to Picklist",
-                                                    style: TextStyle(
-                                                      fontSize: 18,
-                                                      color: Theme.of(context).colorScheme.onSurface,
-                                                    )),
-                                                Icon(Icons.playlist_add,
-                                                    color: Theme.of(context).colorScheme.secondary, size: 24),
-                                              ])))),
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
+                                    children: (prefs.getStringList(
+                                                    "picklist") ??
+                                                [])
+                                            .contains(
+                                                jsonEncode(teamSave.toJson()))
+                                        ? [
+                                            Text(
+                                                "Rank ${prefs.getStringList("picklist")!.indexOf(jsonEncode(teamSave.toJson())) + 1} on Picklist",
+                                                style: TextStyle(
+                                                  fontSize: 18,
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onSurface,
+                                                )),
+                                            Icon(Icons.playlist_add_check,
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .secondary,
+                                                size: 24),
+                                          ]
+                                        : [
+                                            Text("Add to Picklist",
+                                                style: TextStyle(
+                                                  fontSize: 18,
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onSurface,
+                                                )),
+                                            Icon(Icons.playlist_add,
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .secondary,
+                                                size: 24),
+                                          ])))),
                     const SizedBox(height: 28),
                   ]));
               }
@@ -336,7 +373,8 @@ List<Widget> Details(
                       children: [
                         Text(
                           stats.rank.toString(),
-                          style: const TextStyle(fontSize: 64, height: 1, letterSpacing: -2),
+                          style: const TextStyle(
+                              fontSize: 64, height: 1, letterSpacing: -2),
                         ),
                         const SizedBox(
                           height: 5,
@@ -355,9 +393,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.score.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("Score", style: TextStyle(fontSize: 16))
+                                const Text("Score",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             ),
                             const SizedBox(
@@ -368,9 +409,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.driver.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("Driver", style: TextStyle(fontSize: 16))
+                                const Text("Driver",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             ),
                             const SizedBox(
@@ -381,9 +425,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.auton.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("Auto", style: TextStyle(fontSize: 16))
+                                const Text("Auto",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             )
                           ],
@@ -446,7 +493,8 @@ List<Widget> Details(
                       children: [
                         Text(
                           stats.trueSkillGlobalRank.toString(),
-                          style: const TextStyle(fontSize: 64, height: 1, letterSpacing: -2),
+                          style: const TextStyle(
+                              fontSize: 64, height: 1, letterSpacing: -2),
                         ),
                         const SizedBox(
                           height: 5,
@@ -465,9 +513,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.trueSkill.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("Score", style: TextStyle(fontSize: 16))
+                                const Text("Score",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             ),
                             const SizedBox(
@@ -478,9 +529,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.trueSkillRegionRank.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("Region Rank", style: TextStyle(fontSize: 16))
+                                const Text("Region Rank",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             ),
                             const SizedBox(
@@ -498,9 +552,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.opr.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("OPR", style: TextStyle(fontSize: 16))
+                                const Text("OPR",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             ),
                             const SizedBox(
@@ -511,9 +568,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.dpr.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("DPR", style: TextStyle(fontSize: 16))
+                                const Text("DPR",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             ),
                             const SizedBox(
@@ -524,9 +584,12 @@ List<Widget> Details(
                               children: [
                                 Text(
                                   stats.ccwm.toString(),
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
-                                const Text("CCWM", style: TextStyle(fontSize: 16))
+                                const Text("CCWM",
+                                    style: TextStyle(fontSize: 16))
                               ],
                             ),
                           ],
@@ -541,7 +604,7 @@ List<Widget> Details(
       ),
     ),
     const SliverToBoxAdapter(
-      child: const SizedBox(
+      child: SizedBox(
         height: 28,
       ),
     ),
@@ -595,7 +658,8 @@ List<Widget> Details(
                             children: [
                               Text(
                                 stats.wins.toString(),
-                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 16, fontWeight: FontWeight.w500),
                               ),
                               const Text("Wins", style: TextStyle(fontSize: 16))
                             ],
@@ -606,9 +670,11 @@ List<Widget> Details(
                             children: [
                               Text(
                                 stats.losses.toString(),
-                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 16, fontWeight: FontWeight.w500),
                               ),
-                              const Text("Losses", style: TextStyle(fontSize: 16))
+                              const Text("Losses",
+                                  style: TextStyle(fontSize: 16))
                             ],
                           ),
                           const SizedBox(width: 18),
@@ -617,7 +683,8 @@ List<Widget> Details(
                             children: [
                               Text(
                                 stats.ties.toString(),
-                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 16, fontWeight: FontWeight.w500),
                               ),
                               const Text("Ties", style: TextStyle(fontSize: 16))
                             ],
@@ -628,9 +695,11 @@ List<Widget> Details(
                             children: [
                               Text(
                                 stats.matches.toString(),
-                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 16, fontWeight: FontWeight.w500),
                               ),
-                              const Text("Matches", style: TextStyle(fontSize: 16))
+                              const Text("Matches",
+                                  style: TextStyle(fontSize: 16))
                             ],
                           ),
                           const SizedBox(width: 18),
@@ -672,7 +741,7 @@ List<Widget> Details(
                 }
 
                 List<Award> awards = snapshot.data as List<Award>;
-                if (awards.isNotEmpty)
+                if (awards.isNotEmpty) {
                   return Container(
                     padding: const EdgeInsets.all(18),
                     decoration: BoxDecoration(
@@ -688,9 +757,11 @@ List<Widget> Details(
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            const Text("Awards", style: TextStyle(fontSize: 24)),
+                            const Text("Awards",
+                                style: TextStyle(fontSize: 24)),
                             Text(awards.length.toString(),
-                                style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500))
+                                style: const TextStyle(
+                                    fontSize: 24, fontWeight: FontWeight.w500))
                           ],
                         ),
                         const SizedBox(height: 18),
@@ -702,7 +773,8 @@ List<Widget> Details(
                                   alignment: Alignment.centerLeft,
                                   height: 60,
                                   child: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     mainAxisAlignment: MainAxisAlignment.center,
                                     children: [
                                       Text(
@@ -710,7 +782,9 @@ List<Widget> Details(
                                         overflow: TextOverflow.ellipsis,
                                         textAlign: TextAlign.start,
                                         maxLines: 1,
-                                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                        style: const TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w500),
                                       ),
                                       Text(
                                         maxLines: 1,
@@ -723,7 +797,8 @@ List<Widget> Details(
                                   ),
                                 ),
                                 Divider(
-                                  color: Theme.of(context).colorScheme.surfaceDim,
+                                  color:
+                                      Theme.of(context).colorScheme.surfaceDim,
                                 )
                               ],
                             );
@@ -732,8 +807,9 @@ List<Widget> Details(
                       ],
                     ),
                   );
-                else
+                } else {
                   return Container();
+                }
             }
           },
         ),
@@ -776,11 +852,13 @@ List<Widget> Details(
                       return const Text("Tournaments Unavailable");
                     }
 
-                    List<TournamentPreview> tournaments = snapshot.data as List<TournamentPreview>;
+                    List<TournamentPreview> tournaments =
+                        snapshot.data as List<TournamentPreview>;
                     return Column(
                       children: tournaments
                           .map(
-                            (e) => TournamentPreviewWidget(tournamentPreview: e),
+                            (e) =>
+                                TournamentPreviewWidget(tournamentPreview: e),
                           )
                           .toList(),
                     );
@@ -797,5 +875,4 @@ List<Widget> Details(
       ),
     ),
   ];
-  ;
 }

--- a/elapse_app/lib/screens/team_screen/scoutsheet/closed.dart
+++ b/elapse_app/lib/screens/team_screen/scoutsheet/closed.dart
@@ -1,19 +1,22 @@
 import 'dart:ui';
 
 import 'package:elapse_app/classes/ScoutSheet/scoutSheetUi.dart';
-import 'package:elapse_app/extras/database.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 
-List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI sheet, String teamID,
-    String tournamentID, void Function() updateIndex) {
-  Database database = Database();
-
+List<Widget> ClosedState(
+    BuildContext context,
+    String teamNumber,
+    ScoutSheetUI sheet,
+    String teamID,
+    String tournamentID,
+    void Function() updateIndex) {
   Widget photosDisplay = Container(
     decoration: BoxDecoration(
-        borderRadius: BorderRadius.all(Radius.circular(9)), color: Theme.of(context).colorScheme.tertiary),
+        borderRadius: BorderRadius.all(Radius.circular(9)),
+        color: Theme.of(context).colorScheme.tertiary),
     height: 175,
     child: Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -46,7 +49,8 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
                     onTap: () => _openPhotoViewer(context, sheet.photos, 0),
                     child: ClipRRect(
                         borderRadius: BorderRadius.circular(9),
-                        child: Image.network(sheet.photos[0], width: double.infinity, fit: BoxFit.cover,
+                        child: Image.network(sheet.photos[0],
+                            width: double.infinity, fit: BoxFit.cover,
                             loadingBuilder: (context, widget, progress) {
                           if (progress == null) return widget;
                           return Center(
@@ -54,7 +58,8 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
                             width: 20,
                             height: 20,
                             child: CircularProgressIndicator(
-                              value: progress.cumulativeBytesLoaded / progress.expectedTotalBytes!,
+                              value: progress.cumulativeBytesLoaded /
+                                  progress.expectedTotalBytes!,
                             ),
                           ));
                         })))),
@@ -66,10 +71,12 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
                   child: Hero(
                       tag: sheet.photos[1].hashCode,
                       child: GestureDetector(
-                          onTap: () => _openPhotoViewer(context, sheet.photos, 1),
+                          onTap: () =>
+                              _openPhotoViewer(context, sheet.photos, 1),
                           child: ClipRRect(
                               borderRadius: BorderRadius.circular(9),
-                              child: Image.network(sheet.photos[1], width: double.infinity, fit: BoxFit.cover,
+                              child: Image.network(sheet.photos[1],
+                                  width: double.infinity, fit: BoxFit.cover,
                                   loadingBuilder: (context, widget, progress) {
                                 if (progress == null) return widget;
                                 return Center(
@@ -77,7 +84,8 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
                                   width: 20,
                                   height: 20,
                                   child: CircularProgressIndicator(
-                                    value: progress.cumulativeBytesLoaded / progress.expectedTotalBytes!,
+                                    value: progress.cumulativeBytesLoaded /
+                                        progress.expectedTotalBytes!,
                                   ),
                                 ));
                               })))))
@@ -89,45 +97,62 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
                   child: Hero(
                       tag: sheet.photos[2].hashCode,
                       child: GestureDetector(
-                          onTap: () => _openPhotoViewer(context, sheet.photos, 2),
+                          onTap: () =>
+                              _openPhotoViewer(context, sheet.photos, 2),
                           child: ClipRRect(
                               borderRadius: BorderRadius.circular(9),
                               child: sheet.photos.length > 3
                                   ? Stack(children: [
-                                      Image.network(sheet.photos[2], width: double.infinity, fit: BoxFit.cover,
-                                          loadingBuilder: (context, widget, progress) {
+                                      Image.network(sheet.photos[2],
+                                          width: double.infinity,
+                                          fit: BoxFit.cover, loadingBuilder:
+                                              (context, widget, progress) {
                                         if (progress == null) return widget;
                                         return Center(
                                             child: SizedBox(
                                           width: 20,
                                           height: 20,
                                           child: CircularProgressIndicator(
-                                            value: progress.cumulativeBytesLoaded / progress.expectedTotalBytes!,
+                                            value: progress
+                                                    .cumulativeBytesLoaded /
+                                                progress.expectedTotalBytes!,
                                           ),
                                         ));
                                       }),
                                       BackdropFilter(
-                                          filter: ImageFilter.blur(sigmaX: 2.5, sigmaY: 2.5),
+                                          filter: ImageFilter.blur(
+                                              sigmaX: 2.5, sigmaY: 2.5),
                                           child: Container(
-                                              decoration: BoxDecoration(color: Colors.white.withValues(alpha: 0.1)))),
+                                              decoration: BoxDecoration(
+                                                  color: Colors.white
+                                                      .withValues(
+                                                          alpha: 0.1)))),
                                       Center(
                                           child: DefaultTextStyle(
                                               style: const TextStyle(),
-                                              child: Text("${sheet.photos.length - 2}+",
+                                              child: Text(
+                                                  "${sheet.photos.length - 2}+",
                                                   style: TextStyle(
                                                       fontSize: 48,
-                                                      fontWeight: FontWeight.w600,
-                                                      color: Theme.of(context).colorScheme.surface)))),
+                                                      fontWeight:
+                                                          FontWeight.w600,
+                                                      color: Theme.of(context)
+                                                          .colorScheme
+                                                          .surface)))),
                                     ])
-                                  : Image.network(sheet.photos[2], width: double.infinity, fit: BoxFit.cover,
-                                      loadingBuilder: (context, widget, progress) {
+                                  : Image.network(sheet.photos[2],
+                                      width: double.infinity,
+                                      fit: BoxFit.cover, loadingBuilder:
+                                          (context, widget, progress) {
                                       if (progress == null) return widget;
                                       return Center(
                                           child: SizedBox(
                                         width: 20,
                                         height: 20,
                                         child: CircularProgressIndicator(
-                                          value: progress.cumulativeBytesLoaded / progress.expectedTotalBytes!,
+                                          value:
+                                              progress.cumulativeBytesLoaded /
+                                                  progress.expectedTotalBytes!,
                                         ),
                                       ));
                                     })))))
@@ -154,11 +179,16 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
           children: [
             Text("$teamNumber Specs", style: TextStyle(fontSize: 24)),
             SizedBox(height: 18),
-            Text(sheet.intakeType, style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
-            Text("Intake Type", style: TextStyle(fontSize: 12, fontWeight: FontWeight.w400)),
+            Text(sheet.intakeType,
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
+            Text("Intake Type",
+                style: TextStyle(fontSize: 12, fontWeight: FontWeight.w400)),
             SizedBox(height: 12),
             Divider(
-              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2),
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.2),
             ),
             SizedBox(height: 12),
             Row(
@@ -189,11 +219,16 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
             SizedBox(height: 12),
             sheet.otherNotes != ""
                 ? Divider(
-                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2),
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.2),
                   )
                 : SizedBox(),
             sheet.otherNotes != "" ? SizedBox(height: 12) : SizedBox(),
-            sheet.otherNotes != "" ? Text(sheet.otherNotes, style: TextStyle(fontSize: 16)) : SizedBox(),
+            sheet.otherNotes != ""
+                ? Text(sheet.otherNotes, style: TextStyle(fontSize: 16))
+                : SizedBox(),
           ],
         ),
       ),
@@ -243,7 +278,9 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
             SizedBox(
               height: 18,
             ),
-            Text(sheet.autonNotes != "" ? sheet.autonNotes : "No notes provided", style: TextStyle(fontSize: 16)),
+            Text(
+                sheet.autonNotes != "" ? sheet.autonNotes : "No notes provided",
+                style: TextStyle(fontSize: 16)),
           ],
         ),
       ),
@@ -262,13 +299,15 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
                 builder: (context) {
                   return AlertDialog(
                     title: Text("Confirm Deletion"),
-                    content: Text("Are you sure you want to delete this scoutsheet?"),
+                    content: Text(
+                        "Are you sure you want to delete this scoutsheet?"),
                     actions: [
                       TextButton(
                         onPressed: updateIndex,
                         child: Text(
                           "Delete",
-                          style: TextStyle(color: Theme.of(context).colorScheme.error),
+                          style: TextStyle(
+                              color: Theme.of(context).colorScheme.error),
                         ),
                       ),
                       TextButton(
@@ -277,7 +316,8 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
                         },
                         child: Text(
                           "Cancel",
-                          style: TextStyle(color: Theme.of(context).colorScheme.secondary),
+                          style: TextStyle(
+                              color: Theme.of(context).colorScheme.secondary),
                         ),
                       )
                     ],
@@ -295,7 +335,8 @@ List<Widget> ClosedState(BuildContext context, String teamNumber, ScoutSheetUI s
   ];
 }
 
-void _openPhotoViewer(BuildContext context, List<dynamic> photos, int initIndex) {
+void _openPhotoViewer(
+    BuildContext context, List<dynamic> photos, int initIndex) {
   Navigator.push(context, MaterialPageRoute(builder: (context) {
     return Scaffold(
         body: Container(
@@ -311,8 +352,10 @@ void _openPhotoViewer(BuildContext context, List<dynamic> photos, int initIndex)
                   return PhotoViewGalleryPageOptions(
                     imageProvider: NetworkImage(photos[index]),
                     initialScale: PhotoViewComputedScale.contained,
-                    heroAttributes:
-                        PhotoViewHeroAttributes(tag: index > 2 ? photos[2].hashCode : photos[index].hashCode),
+                    heroAttributes: PhotoViewHeroAttributes(
+                        tag: index > 2
+                            ? photos[2].hashCode
+                            : photos[index].hashCode),
                   );
                 },
                 scrollPhysics: const BouncingScrollPhysics(),
@@ -321,7 +364,10 @@ void _openPhotoViewer(BuildContext context, List<dynamic> photos, int initIndex)
                   width: 20,
                   height: 20,
                   child: CircularProgressIndicator(
-                    value: event != null ? event.cumulativeBytesLoaded / event.expectedTotalBytes! : null,
+                    value: event != null
+                        ? event.cumulativeBytesLoaded /
+                            event.expectedTotalBytes!
+                        : null,
                   ),
                 )),
                 pageController: PageController(initialPage: initIndex),

--- a/elapse_app/lib/screens/team_screen/scoutsheet/edit.dart
+++ b/elapse_app/lib/screens/team_screen/scoutsheet/edit.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:elapse_app/classes/ScoutSheet/scoutSheetUi.dart';
-import 'package:elapse_app/screens/team_screen/camera/camera.dart';
 import 'package:elapse_app/screens/team_screen/camera/photo_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 
@@ -24,14 +21,19 @@ List<Widget> EditState(
     },
     child: Container(
       decoration: BoxDecoration(
-          borderRadius: const BorderRadius.all(Radius.circular(9)), color: Theme.of(context).colorScheme.tertiary),
+          borderRadius: const BorderRadius.all(Radius.circular(9)),
+          color: Theme.of(context).colorScheme.tertiary),
       height: 175,
       child: const Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Column(
             mainAxisAlignment: MainAxisAlignment.center,
-            children: [Icon(Icons.add_photo_alternate_outlined), SizedBox(height: 5), Text("Add Photo")],
+            children: [
+              Icon(Icons.add_photo_alternate_outlined),
+              SizedBox(height: 5),
+              Text("Add Photo")
+            ],
           ),
         ],
       ),
@@ -61,7 +63,9 @@ List<Widget> EditState(
                 Container(
                   height: 50,
                   width: 50,
-                  decoration: BoxDecoration(shape: BoxShape.circle, color: Colors.black.withValues(alpha: 0.5)),
+                  decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Colors.black.withValues(alpha: 0.5)),
                 ),
                 IconButton(
                     onPressed: () {
@@ -86,10 +90,12 @@ List<Widget> EditState(
                       },
                       child: Container(
                         decoration: BoxDecoration(
-                            borderRadius: const BorderRadius.all(Radius.circular(9)),
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(9)),
                             color: Theme.of(context).colorScheme.tertiary),
                         height: 175,
-                        child: const Icon(Icons.add_photo_alternate_outlined, size: 40),
+                        child: const Icon(Icons.add_photo_alternate_outlined,
+                            size: 40),
                       ),
                     )
                   ]
@@ -114,7 +120,7 @@ List<Widget> EditState(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              "${teamNumber} Specs",
+              "$teamNumber Specs",
               style: TextStyle(fontSize: 24),
             ),
             SizedBox(height: 18),
@@ -133,7 +139,8 @@ List<Widget> EditState(
                   flex: 2,
                   fit: FlexFit.tight,
                   child: TextFormField(
-                    decoration: ElapseInputDecoration(context, "# of DT Motors"),
+                    decoration:
+                        ElapseInputDecoration(context, "# of DT Motors"),
                     onChanged: (value) {
                       updateProperty("numMotors", value);
                     },
@@ -248,7 +255,8 @@ InputDecoration ElapseInputDecoration(BuildContext context, String label) {
     ),
     focusedBorder: OutlineInputBorder(
       borderRadius: BorderRadius.all(Radius.circular(9)),
-      borderSide: BorderSide(color: Theme.of(context).colorScheme.primary, width: 2),
+      borderSide:
+          BorderSide(color: Theme.of(context).colorScheme.primary, width: 2),
     ),
   );
 }

--- a/elapse_app/lib/screens/team_screen/team_screen.dart
+++ b/elapse_app/lib/screens/team_screen/team_screen.dart
@@ -28,7 +28,8 @@ import '../widgets/big_error_message.dart';
 import '../widgets/long_button.dart';
 
 class TeamScreen extends StatefulWidget {
-  const TeamScreen({super.key, required this.teamID, required this.teamNumber, this.team});
+  const TeamScreen(
+      {super.key, required this.teamID, required this.teamNumber, this.team});
   final int teamID;
   final String teamNumber;
   final Team? team;
@@ -74,7 +75,8 @@ class _TeamScreenState extends State<TeamScreen> {
   @override
   void initState() {
     super.initState();
-    teamSave = TeamPreview(teamID: widget.teamID, teamNumber: widget.teamNumber);
+    teamSave =
+        TeamPreview(teamID: widget.teamID, teamNumber: widget.teamNumber);
     isSaved = false;
     displaySave = true;
     team = fetchTeam(widget.teamID).then(
@@ -98,12 +100,15 @@ class _TeamScreenState extends State<TeamScreen> {
           setState(() {
             selectedTournament = value[0];
           });
-          scoutSheet =
-              database.getTeamScoutSheetInfo(teamGroupID, widget.teamID.toString(), value[0].id.toString()).then(
+          scoutSheet = database
+              .getTeamScoutSheetInfo(
+                  teamGroupID, widget.teamID.toString(), value[0].id.toString())
+              .then(
             (value) {
               if (value != null) {
                 print(value.data());
-                Map<String, dynamic> sheet = value.data() as Map<String, dynamic>;
+                Map<String, dynamic> sheet =
+                    value.data() as Map<String, dynamic>;
                 Map<String, dynamic> specs = sheet["properties"]["Specs"];
                 setState(() {
                   scoutsheetID = value.id;
@@ -147,7 +152,8 @@ class _TeamScreenState extends State<TeamScreen> {
   }
 
   bool isMainTeam() {
-    return jsonDecode(prefs.getString("savedTeam") ?? "")["teamID"] == widget.teamID.toString();
+    return jsonDecode(prefs.getString("savedTeam") ?? "")["teamID"] ==
+        widget.teamID.toString();
   }
 
   void toggleSaveTeam() {
@@ -173,13 +179,14 @@ class _TeamScreenState extends State<TeamScreen> {
   void addPhoto(String photo) {
     setState(() {
       activeScoutSheet.photos.add(photo);
-      database.addPhoto(teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), photo);
+      database.addPhoto(teamGroupID, widget.teamID.toString(),
+          selectedTournament.id.toString(), photo);
     });
   }
 
   void removePhoto(int index) async {
-    await database.deletePhoto(
-        teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), activeScoutSheet.photos[index]);
+    await database.deletePhoto(teamGroupID, widget.teamID.toString(),
+        selectedTournament.id.toString(), activeScoutSheet.photos[index]);
     setState(() {
       activeScoutSheet.photos.removeAt(index);
     });
@@ -192,35 +199,55 @@ class _TeamScreenState extends State<TeamScreen> {
           activeScoutSheet.intakeType = value;
         });
         await database.updateProperty(
-            teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), "Specs", activeScoutSheet.toMap());
+            teamGroupID,
+            widget.teamID.toString(),
+            selectedTournament.id.toString(),
+            "Specs",
+            activeScoutSheet.toMap());
         break;
       case "numMotors":
         setState(() {
           activeScoutSheet.numMotors = value;
         });
         await database.updateProperty(
-            teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), "Specs", activeScoutSheet.toMap());
+            teamGroupID,
+            widget.teamID.toString(),
+            selectedTournament.id.toString(),
+            "Specs",
+            activeScoutSheet.toMap());
         break;
       case "RPM":
         setState(() {
           activeScoutSheet.RPM = value;
         });
         await database.updateProperty(
-            teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), "Specs", activeScoutSheet.toMap());
+            teamGroupID,
+            widget.teamID.toString(),
+            selectedTournament.id.toString(),
+            "Specs",
+            activeScoutSheet.toMap());
         break;
       case "otherNotes":
         setState(() {
           activeScoutSheet.otherNotes = value;
         });
         await database.updateProperty(
-            teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), "Specs", activeScoutSheet.toMap());
+            teamGroupID,
+            widget.teamID.toString(),
+            selectedTournament.id.toString(),
+            "Specs",
+            activeScoutSheet.toMap());
         break;
       case "autonNotes":
         setState(() {
           activeScoutSheet.autonNotes = value;
         });
         await database.updateProperty(
-            teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), "Specs", activeScoutSheet.toMap());
+            teamGroupID,
+            widget.teamID.toString(),
+            selectedTournament.id.toString(),
+            "Specs",
+            activeScoutSheet.toMap());
         break;
     }
   }
@@ -229,15 +256,20 @@ class _TeamScreenState extends State<TeamScreen> {
   late bool displaySave;
   @override
   Widget build(BuildContext context) {
-    List<Widget> DetailsScreen =
-        Details(context, widget.teamNumber, teamSave, displaySave, isSaved, toggleSaveTeam, () {
+    List<Widget> DetailsScreen = Details(context, widget.teamNumber, teamSave,
+        displaySave, isSaved, toggleSaveTeam, () {
       setState(() {});
-    }, widget.team, team, teamStats, teamAwards, teamTournaments, tournament, skillsStats);
+    }, widget.team, team, teamStats, teamAwards, teamTournaments, tournament,
+        skillsStats);
 
     List<Widget> ScoutSheetClosedScreen = ClosedState(
-        context, widget.teamNumber, activeScoutSheet, widget.teamID.toString(), selectedTournament.id.toString(),
-        () async {
-      await database.removeTeamScoutSheet(widget.teamID.toString(), teamGroupID, selectedTournament.id.toString());
+        context,
+        widget.teamNumber,
+        activeScoutSheet,
+        widget.teamID.toString(),
+        selectedTournament.id.toString(), () async {
+      await database.removeTeamScoutSheet(widget.teamID.toString(), teamGroupID,
+          selectedTournament.id.toString());
       setState(() {
         scoutSheetStateIndex = 0;
         activeScoutSheet = ScoutSheetUI(
@@ -252,73 +284,88 @@ class _TeamScreenState extends State<TeamScreen> {
       Navigator.pop(context);
     });
     List<Widget> ScoutsheetEditScreen = EditState(
-        context, widget.teamNumber, addPhoto, removePhoto, activeScoutSheet.photos, updateSheet, activeScoutSheet);
-    List<Widget> ScoutSheetEmpty = selectedTournament.id != 0 && teamGroupID.isNotEmpty
-        ? EmptyState(context, () async {
-            showDialog(
-              barrierDismissible: false,
-              context: context,
-              builder: (context) {
-                return AlertDialog(
-                  title: Text("Creating Scoutsheet"),
-                  content: Text("You will be able to edit once the scoutsheet is created"),
+        context,
+        widget.teamNumber,
+        addPhoto,
+        removePhoto,
+        activeScoutSheet.photos,
+        updateSheet,
+        activeScoutSheet);
+    List<Widget> ScoutSheetEmpty =
+        selectedTournament.id != 0 && teamGroupID.isNotEmpty
+            ? EmptyState(context, () async {
+                showDialog(
+                  barrierDismissible: false,
+                  context: context,
+                  builder: (context) {
+                    return AlertDialog(
+                      title: Text("Creating Scoutsheet"),
+                      content: Text(
+                          "You will be able to edit once the scoutsheet is created"),
+                    );
+                  },
                 );
-              },
-            );
-            await database
-                .createTeamScoutSheet(teamGroupID, widget.teamID.toString(), selectedTournament.id.toString())
-                .then(
-              (id) async {
-                await database.updateMemberEditing(
-                    teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), true);
-                print(id);
-                Navigator.pop(context);
-                setState(() {
-                  scoutsheetID = id;
-                  scoutSheetStateIndex = 2;
-                });
-              },
-            );
-          })
-        : [
-            SliverToBoxAdapter(
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(18),
-                  border: Border.all(
-                    color: Theme.of(context).colorScheme.primary,
-                    width: 2,
+                await database
+                    .createTeamScoutSheet(teamGroupID, widget.teamID.toString(),
+                        selectedTournament.id.toString())
+                    .then(
+                  (id) async {
+                    await database.updateMemberEditing(
+                        teamGroupID,
+                        widget.teamID.toString(),
+                        selectedTournament.id.toString(),
+                        true);
+                    print(id);
+                    Navigator.pop(context);
+                    setState(() {
+                      scoutsheetID = id;
+                      scoutSheetStateIndex = 2;
+                    });
+                  },
+                );
+              })
+            : [
+                SliverToBoxAdapter(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(18),
+                      border: Border.all(
+                        color: Theme.of(context).colorScheme.primary,
+                        width: 2,
+                      ),
+                    ),
+                    margin: EdgeInsets.only(left: 23, right: 23, top: 8),
+                    padding: EdgeInsets.all(18),
+                    alignment: Alignment.center,
+                    child: Column(children: [
+                      BigErrorMessage(
+                        icon: Icons.people_alt_outlined,
+                        message: "Not in a team group",
+                        topPadding: 0,
+                        textPadding: 5,
+                      ),
+                      const SizedBox(height: 18),
+                      LongButton(
+                          onPressed: () async {
+                            await Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => GroupSetupPage()));
+                            setState(() {
+                              teamGroupID = prefs.getString("teamGroup") ?? "";
+                            });
+                          },
+                          text: "Set Up a Team Group")
+                    ]),
                   ),
-                ),
-                margin: EdgeInsets.only(left: 23, right: 23, top: 8),
-                padding: EdgeInsets.all(18),
-                alignment: Alignment.center,
-                child: Column(children: [
-                  BigErrorMessage(
-                    icon: Icons.people_alt_outlined,
-                    message: "Not in a team group",
-                    topPadding: 0,
-                    textPadding: 5,
-                  ),
-                  const SizedBox(height: 18),
-                  LongButton(
-                      onPressed: () async {
-                        await Navigator.push(context, MaterialPageRoute(builder: (context) => GroupSetupPage()));
-                        setState(() {
-                          teamGroupID = prefs.getString("teamGroup") ?? "";
-                        });
-                      },
-                      text: "Set Up a Team Group")
-                ]),
-              ),
-            )
-          ];
+                )
+              ];
 
-    List<Widget> ScoutSheetCurrentlyEditing = [
-      SliverToBoxAdapter(child: Text("ScoutSheet is currently being edited from another member"))
+    List<List<Widget>> ScoutSheetScreens = [
+      ScoutSheetEmpty,
+      ScoutSheetClosedScreen,
+      ScoutsheetEditScreen
     ];
-
-    List<List<Widget>> ScoutSheetScreens = [ScoutSheetEmpty, ScoutSheetClosedScreen, ScoutsheetEditScreen];
 
     Widget button;
 
@@ -342,7 +389,10 @@ class _TeamScreenState extends State<TeamScreen> {
         button = IconButton(
           onPressed: () async {
             await database.updateMemberEditing(
-                teamGroupID, widget.teamID.toString(), selectedTournament.id.toString(), false);
+                teamGroupID,
+                widget.teamID.toString(),
+                selectedTournament.id.toString(),
+                false);
             setState(() {
               scoutSheetStateIndex = 1;
             });
@@ -397,7 +447,8 @@ class _TeamScreenState extends State<TeamScreen> {
                       ? FutureBuilder<Object>(
                           future: teamTournaments,
                           builder: (context, snapshot) {
-                            if (snapshot.connectionState == ConnectionState.waiting) {
+                            if (snapshot.connectionState ==
+                                ConnectionState.waiting) {
                               return Text(
                                 "Loading...",
                                 style: TextStyle(
@@ -417,7 +468,8 @@ class _TeamScreenState extends State<TeamScreen> {
                                     fontWeight: FontWeight.w500),
                               );
                             }
-                            List<TournamentPreview> tournaments = snapshot.data as List<TournamentPreview>;
+                            List<TournamentPreview> tournaments =
+                                snapshot.data as List<TournamentPreview>;
                             if (tournaments.isEmpty) {
                               return Text(
                                 "No Tournaments",
@@ -441,7 +493,9 @@ class _TeamScreenState extends State<TeamScreen> {
                                     fontSize: 15.9,
                                     letterSpacing: 0.25,
                                     fontWeight: FontWeight.w500,
-                                    color: Theme.of(context).colorScheme.onSurface),
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurface),
                                 items: tournaments.map((tournament) {
                                   return DropdownMenuItem(
                                     value: tournament.id,
@@ -459,12 +513,17 @@ class _TeamScreenState extends State<TeamScreen> {
                                   setState(
                                     () {
                                       selectedTournamentIndex =
-                                          tournaments.indexWhere((element) => element.id == value);
-                                      selectedTournament = tournaments[selectedTournamentIndex];
+                                          tournaments.indexWhere(
+                                              (element) => element.id == value);
+                                      selectedTournament =
+                                          tournaments[selectedTournamentIndex];
                                       if (teamGroupID.isNotEmpty) {
                                         scoutSheet = database
                                             .getTeamScoutSheetInfo(
-                                                teamGroupID, widget.teamID.toString(), selectedTournament.id.toString())
+                                                teamGroupID,
+                                                widget.teamID.toString(),
+                                                selectedTournament.id
+                                                    .toString())
                                             .then(
                                           (value) {
                                             if (value != null) {
@@ -525,7 +584,8 @@ class _TeamScreenState extends State<TeamScreen> {
                 onTap: () {
                   Navigator.pop(context);
                 },
-                child: Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.onSurface),
+                child: Icon(Icons.arrow_back,
+                    color: Theme.of(context).colorScheme.onSurface),
               ),
               const Spacer(),
               GestureDetector(
@@ -533,14 +593,18 @@ class _TeamScreenState extends State<TeamScreen> {
                     Season updated = await Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => SeasonFilterPage(selected: season),
+                        builder: (context) =>
+                            SeasonFilterPage(selected: season),
                       ),
                     );
                     setState(() {
                       season = updated;
-                      skillsStats = getWorldSkillsForTeam(season.vrcId, widget.teamID);
-                      teamStats = getTrueSkillDataForTeam(season.vrcId, widget.teamNumber);
-                      teamTournaments = fetchTeamTournaments(widget.teamID, season.vrcId);
+                      skillsStats =
+                          getWorldSkillsForTeam(season.vrcId, widget.teamID);
+                      teamStats = getTrueSkillDataForTeam(
+                          season.vrcId, widget.teamNumber);
+                      teamTournaments =
+                          fetchTeamTournaments(widget.teamID, season.vrcId);
                       teamAwards = getAwards(widget.teamID, season.vrcId);
                     });
                   },
@@ -605,11 +669,12 @@ class TeamBio extends StatelessWidget {
                 children: [
                   Text(
                     getGrade(grade),
-                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.w500),
                   ),
                   const Text(
                     "Grade",
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                     ),
                   ),
@@ -627,11 +692,12 @@ class TeamBio extends StatelessWidget {
                     getLocation(location),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.w500),
                   ),
                   const Text(
                     "Location",
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                     ),
                   ),
@@ -655,11 +721,12 @@ class TeamBio extends StatelessWidget {
                   Text(
                     teamName,
                     maxLines: 1,
-                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.w500),
                   ),
                   const Text(
                     "Team Name",
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 16,
                     ),
                   ),

--- a/elapse_app/lib/screens/tournament/pages/info/award_widget.dart
+++ b/elapse_app/lib/screens/tournament/pages/info/award_widget.dart
@@ -10,7 +10,8 @@ class AwardWidget extends StatelessWidget {
     String winnersString;
     if (award.teamWinners != null && award.teamWinners!.isNotEmpty) {
       winnersString = award.teamWinners!.map((e) => e.teamNumber).join(", ");
-    } else if (award.individualWinners != null && award.individualWinners!.isNotEmpty) {
+    } else if (award.individualWinners != null &&
+        award.individualWinners!.isNotEmpty) {
       winnersString = award.individualWinners!.join(", ");
     } else {
       winnersString = "N/A";
@@ -38,14 +39,22 @@ class AwardWidget extends StatelessWidget {
                 flex: 1,
                 child: Text(
                   award.qualifications.join(", "),
-                  style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7)),
+                  style: TextStyle(
+                      fontSize: 18,
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withValues(alpha: 0.7)),
                 ),
               )
             ],
           ),
           Text(
             winnersString,
-            style: TextStyle(fontSize: 18, color: Theme.of(context).colorScheme.secondary, fontWeight: FontWeight.w500),
+            style: TextStyle(
+                fontSize: 18,
+                color: Theme.of(context).colorScheme.secondary,
+                fontWeight: FontWeight.w500),
           ),
           SizedBox(
             height: 5,

--- a/elapse_app/lib/screens/tournament/pages/info/info.dart
+++ b/elapse_app/lib/screens/tournament/pages/info/info.dart
@@ -29,7 +29,8 @@ class InfoPage extends StatelessWidget {
           children: [
             Container(
               decoration: BoxDecoration(
-                  border: Border.all(color: Theme.of(context).colorScheme.primary, width: 1),
+                  border: Border.all(
+                      color: Theme.of(context).colorScheme.primary, width: 1),
                   borderRadius: BorderRadius.circular(18)),
               padding: EdgeInsets.all(18),
               child: Column(
@@ -51,7 +52,8 @@ class InfoPage extends StatelessWidget {
                   ),
                   TextButton(
                     style: TextButton.styleFrom(
-                        foregroundColor: Theme.of(context).colorScheme.secondary,
+                        foregroundColor:
+                            Theme.of(context).colorScheme.secondary,
                         padding: EdgeInsets.only(right: 10, bottom: 10)),
                     onPressed: () {
                       launchUrl(Uri.https("events.vex.com",
@@ -94,7 +96,8 @@ class InfoPage extends StatelessWidget {
                   ),
                   TextButton(
                     style: TextButton.styleFrom(
-                        foregroundColor: Theme.of(context).colorScheme.secondary,
+                        foregroundColor:
+                            Theme.of(context).colorScheme.secondary,
                         padding: EdgeInsets.only(right: 10, bottom: 10)),
                     onPressed: () {
                       MapsLauncher.launchQuery(
@@ -119,9 +122,11 @@ class InfoPage extends StatelessWidget {
                           fontWeight: FontWeight.w500,
                         ),
                       ),
-                      tournament.endDate != null && tournament.endDate != tournament.startDate
+                      tournament.endDate != null &&
+                              tournament.endDate != tournament.startDate
                           ? Text(
-                              DateFormat("EEE, MMM d, y").format(tournament.endDate!),
+                              DateFormat("EEE, MMM d, y")
+                                  .format(tournament.endDate!),
                               style: const TextStyle(
                                 fontSize: 24,
                                 fontWeight: FontWeight.w500,
@@ -158,8 +163,11 @@ class InfoPage extends StatelessWidget {
                                   ),
                                   TextButton.icon(
                                     style: TextButton.styleFrom(
-                                        foregroundColor: Theme.of(context).colorScheme.secondary,
-                                        padding: const EdgeInsets.only(right: 10, bottom: 10)),
+                                        foregroundColor: Theme.of(context)
+                                            .colorScheme
+                                            .secondary,
+                                        padding: const EdgeInsets.only(
+                                            right: 10, bottom: 10)),
                                     onPressed: () {
                                       launchUrl(Uri.parse(
                                           "https://events.vex.com/robot-competitions/vex-robotics-competition/${tournament.sku}.html#webcast"));
@@ -214,8 +222,9 @@ class InfoPage extends StatelessWidget {
             ),
             Container(
               width: double.infinity,
-              decoration:
-                  BoxDecoration(color: Theme.of(context).colorScheme.tertiary, borderRadius: BorderRadius.circular(18)),
+              decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.tertiary,
+                  borderRadius: BorderRadius.circular(18)),
               padding: EdgeInsets.all(18),
               child: Column(
                 children: [
@@ -230,7 +239,9 @@ class InfoPage extends StatelessWidget {
                     height: 15,
                   ),
                   Column(
-                    children: awards.map((award) => AwardWidget(award: award)).toList(),
+                    children: awards
+                        .map((award) => AwardWidget(award: award))
+                        .toList(),
                   )
                 ],
               ),
@@ -246,8 +257,8 @@ class InfoPage extends StatelessWidget {
 }
 
 Future<bool> hasLivestream(String sku) async {
-  final response = await http
-      .get(Uri.parse("https://events.vex.com/robot-competitions/vex-robotics-competition/$sku.html#general-info"));
+  final response = await http.get(Uri.parse(
+      "https://events.vex.com/robot-competitions/vex-robotics-competition/$sku.html#general-info"));
   print(response.body.contains("<h4>Webcast</h4>"));
   return response.body.contains("<h4>Webcast</h4>");
 }

--- a/elapse_app/lib/screens/tournament/pages/main/loaded.dart
+++ b/elapse_app/lib/screens/tournament/pages/main/loaded.dart
@@ -24,7 +24,6 @@ import '../../../../classes/Filters/gradeLevel.dart';
 import '../../../../classes/Filters/season.dart';
 import '../../../../classes/Team/vdaStats.dart';
 import '../../../../classes/Team/world_skills.dart';
-import '../../../../classes/Tournament/tskills.dart';
 
 class TournamentLoadedScreen extends StatefulWidget {
   final Tournament tournament;
@@ -39,12 +38,30 @@ class TournamentLoadedScreen extends StatefulWidget {
   State<TournamentLoadedScreen> createState() => _TournamentLoadedScreenState();
 }
 
-class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with TickerProviderStateMixin {
+class _TournamentLoadedScreenState extends State<TournamentLoadedScreen>
+    with TickerProviderStateMixin {
   late int selectedIndex;
   int sortIndex = 0;
   List<String> titles = ["Schedule", "Rankings", "Skills", "Info"];
-  List<String> rankingSorts = ["Rank", "AP", "SP", "AWP", "OPR", "DPR", "CCWM", "Skills", "World Skills", "TrueSkill"];
-  List<String> skillsSorts = ["Rank", "Driver", "Auton", "Driver Attempts", "Auton Attempts"];
+  List<String> rankingSorts = [
+    "Rank",
+    "AP",
+    "SP",
+    "AWP",
+    "OPR",
+    "DPR",
+    "CCWM",
+    "Skills",
+    "World Skills",
+    "TrueSkill"
+  ];
+  List<String> skillsSorts = [
+    "Rank",
+    "Driver",
+    "Auton",
+    "Driver Attempts",
+    "Auton Attempts"
+  ];
   TournamentRankingsFilter filter = TournamentRankingsFilter();
 
   double _fadeStart = 0, _fadeEnd = 1;
@@ -79,15 +96,19 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
       useSavedTeams = !useSavedTeams;
       if (useSavedTeams) {
         final String savedTeam = prefs.getString("savedTeam") ?? "";
-        TeamPreview savedTeamPreview =
-            TeamPreview(teamID: jsonDecode(savedTeam)["teamID"], teamNumber: jsonDecode(savedTeam)["teamNumber"]);
+        TeamPreview savedTeamPreview = TeamPreview(
+            teamID: jsonDecode(savedTeam)["teamID"],
+            teamNumber: jsonDecode(savedTeam)["teamNumber"]);
         List<String> savedTeamsString = prefs.getStringList("savedTeams") ?? [];
         savedTeams.add(savedTeamPreview);
         savedTeams.addAll(savedTeamsString
-            .map((e) => TeamPreview(teamID: jsonDecode(e)["teamID"], teamNumber: jsonDecode(e)["teamNumber"]))
+            .map((e) => TeamPreview(
+                teamID: jsonDecode(e)["teamID"],
+                teamNumber: jsonDecode(e)["teamNumber"]))
             .toList());
         rankingsTeams = widget.tournament.teams
-            .where((element) => savedTeams.any((element2) => element2.teamID == element.id))
+            .where((element) =>
+                savedTeams.any((element2) => element2.teamID == element.id))
             .toList();
       } else {
         rankingsTeams = widget.tournament.teams;
@@ -105,11 +126,12 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
     savedQuery = "";
     _scrollController = ScrollController();
 
-    worldSkillsStats =
-        getWorldSkillsRankings(widget.tournament.seasonID, getGradeLevel(prefs.getString("defaultGrade")));
+    worldSkillsStats = getWorldSkillsRankings(widget.tournament.seasonID,
+        getGradeLevel(prefs.getString("defaultGrade")));
     vdaStats = getTrueSkillData(widget.tournament.seasonID);
 
-    if (widget.tournament.divisions[0].games == null || widget.tournament.divisions[0].games!.isEmpty) {
+    if (widget.tournament.divisions[0].games == null ||
+        widget.tournament.divisions[0].games!.isEmpty) {
       selectedIndex = 3;
     } else {
       selectedIndex = 0;
@@ -128,14 +150,17 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
     if (division.games != null && division.games!.isNotEmpty) {
       adjustMatchTiming(division.games!);
       practice = division.games!.where((game) => game.roundNum == 1).toList();
-      qualifications = division.games!.where((game) => game.roundNum == 2).toList();
-      eliminations = division.games!.where((game) => game.roundNum > 2).toList();
+      qualifications =
+          division.games!.where((game) => game.roundNum == 2).toList();
+      eliminations =
+          division.games!.where((game) => game.roundNum > 2).toList();
     }
 
     List<Widget> pages = [
       SliverToBoxAdapter(),
       hasCachedWorldSkillsRankings(
-                  getGradeLevel(prefs.getString("defaultGrade")) == gradeLevels["College"]
+                  getGradeLevel(prefs.getString("defaultGrade")) ==
+                          gradeLevels["College"]
                       ? seasons[0].vexUId!
                       : seasons[0].vrcId,
                   getGradeLevel(prefs.getString("defaultGrade"))) &&
@@ -149,20 +174,27 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
               worldSkills: jsonDecode(prefs.getString("worldSkillsData")!)
                   .map<WorldSkillsStats>((e) => WorldSkillsStats.fromJson(e))
                   .toList(),
-              vda: jsonDecode(prefs.getString("vdaData")!).map<VDAStats>((json) => VDAStats.fromJson(json)).toList(),
+              vda: jsonDecode(prefs.getString("vdaData")!)
+                  .map<VDAStats>((json) => VDAStats.fromJson(json))
+                  .toList(),
             )
           : FutureBuilder(
-              future: Future.wait(sortIndex == 9 ? [worldSkillsStats, vdaStats] : [worldSkillsStats]),
+              future: Future.wait(sortIndex == 9
+                  ? [worldSkillsStats, vdaStats]
+                  : [worldSkillsStats]),
               builder: (context, snapshot) {
                 switch (snapshot.connectionState) {
                   case ConnectionState.none:
                   case ConnectionState.waiting:
                   case ConnectionState.active:
-                    return const SliverToBoxAdapter(child: LinearProgressIndicator());
+                    return const SliverToBoxAdapter(
+                        child: LinearProgressIndicator());
                   case ConnectionState.done:
                     if (snapshot.hasError) {
                       return const SliverToBoxAdapter(
-                          child: BigErrorMessage(icon: Icons.list_outlined, message: "Unable to load rankings"));
+                          child: BigErrorMessage(
+                              icon: Icons.list_outlined,
+                              message: "Unable to load rankings"));
                     }
 
                     return RankingsPage(
@@ -172,14 +204,16 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                       filter: filter,
                       skills: widget.tournament.tournamentSkills!,
                       worldSkills: snapshot.data?[0] as List<WorldSkillsStats>,
-                      vda: sortIndex == 9 ? (snapshot.data?[1] as List<VDAStats>) : null,
+                      vda: sortIndex == 9
+                          ? (snapshot.data?[1] as List<VDAStats>)
+                          : null,
                     );
                 }
               }),
       SkillsPage(
-          skills: widget.tournament.tournamentSkills!,
-          teams: widget.tournament.teams,
-          divisions: widget.tournament.divisions,
+        skills: widget.tournament.tournamentSkills!,
+        teams: widget.tournament.teams,
+        divisions: widget.tournament.divisions,
         sort: sortIndex,
         filter: filter,
       ),
@@ -194,15 +228,16 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
         backgroundColor: Theme.of(context).colorScheme.surface,
         body: RefreshIndicator(
           onRefresh: () async {
-            Tournament tournament = await getTournamentDetails(widget.tournament.id);
+            Tournament tournament =
+                await getTournamentDetails(widget.tournament.id);
             setState(() {
               rankingsTeams = tournament.teams;
               inSearch = false;
               searchQuery = "";
               savedQuery = "";
 
-              worldSkillsStats =
-                  getWorldSkillsRankings(tournament.seasonID, getGradeLevel(prefs.getString("defaultGrade")));
+              worldSkillsStats = getWorldSkillsRankings(tournament.seasonID,
+                  getGradeLevel(prefs.getString("defaultGrade")));
               vdaStats = getTrueSkillData(tournament.seasonID);
             });
           },
@@ -215,7 +250,8 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                   children: [
                     Text(
                       titles[selectedIndex],
-                      style: TextStyle(fontSize: 24, fontWeight: FontWeight.w600),
+                      style:
+                          TextStyle(fontSize: 24, fontWeight: FontWeight.w600),
                     ),
                     Spacer(),
                     GestureDetector(
@@ -227,12 +263,16 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                           context,
                           PageRouteBuilder(
                             transitionDuration: Duration(milliseconds: 300),
-                            reverseTransitionDuration: Duration(milliseconds: 300),
-                            pageBuilder: (context, animation, secondaryAnimation) => SearchScreen(
+                            reverseTransitionDuration:
+                                Duration(milliseconds: 300),
+                            pageBuilder:
+                                (context, animation, secondaryAnimation) =>
+                                    SearchScreen(
                               tournament: widget.tournament,
                               division: division,
                             ),
-                            transitionsBuilder: (context, animation, secondaryAnimation, child) {
+                            transitionsBuilder: (context, animation,
+                                secondaryAnimation, child) {
                               // Create a Tween that transitions the new screen from fully transparent to fully opaque
                               return FadeTransition(
                                 opacity: animation,
@@ -249,28 +289,35 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                 backNavigation: widget.isPreview,
                 background: SafeArea(
                   child: Padding(
-                    padding: const EdgeInsets.only(left: 23, right: 12, bottom: 20, top: 10),
+                    padding: const EdgeInsets.only(
+                        left: 23, right: 12, bottom: 20, top: 10),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         widget.isPreview
                             ? Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
                                   GestureDetector(
                                     onTap: () {
                                       Navigator.pop(context);
                                     },
-                                    child: Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.onSurface),
+                                    child: Icon(Icons.arrow_back,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface),
                                   ),
                                   Spacer(),
                                   widget.tournament.divisions.isNotEmpty
                                       ? DropdownButton<Division>(
                                           value: division,
-                                          borderRadius: BorderRadius.circular(20),
-                                          items:
-                                              widget.tournament.divisions.map<DropdownMenuItem<Division>>((division) {
+                                          borderRadius:
+                                              BorderRadius.circular(20),
+                                          items: widget.tournament.divisions
+                                              .map<DropdownMenuItem<Division>>(
+                                                  (division) {
                                             return DropdownMenuItem(
                                                 value: division,
                                                 child: Row(
@@ -295,12 +342,15 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                                 ],
                               )
                             : Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
                                   DropdownButton<Division>(
                                     value: division,
                                     borderRadius: BorderRadius.circular(20),
-                                    items: widget.tournament.divisions.map<DropdownMenuItem<Division>>((division) {
+                                    items: widget.tournament.divisions
+                                        .map<DropdownMenuItem<Division>>(
+                                            (division) {
                                       return DropdownMenuItem(
                                           value: division,
                                           child: Row(
@@ -446,7 +496,9 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                   maxHeight: 70.0,
                   child: Stack(
                     children: [
-                      Container(height: 300, color: Theme.of(context).colorScheme.primary),
+                      Container(
+                          height: 300,
+                          color: Theme.of(context).colorScheme.primary),
                       Container(
                         decoration: BoxDecoration(
                           color: Theme.of(context).colorScheme.surface,
@@ -456,13 +508,16 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                           ),
                         ),
                         child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 25, vertical: 13),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 25, vertical: 13),
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               _buildIconButton(context, Icons.schedule, 0),
-                              _buildIconButton(context, Icons.format_list_numbered_outlined, 1),
-                              _buildIconButton(context, Icons.sports_esports_outlined, 2),
+                              _buildIconButton(context,
+                                  Icons.format_list_numbered_outlined, 1),
+                              _buildIconButton(
+                                  context, Icons.sports_esports_outlined, 2),
                               _buildIconButton(context, Icons.info_outlined, 3),
                             ],
                           ),
@@ -517,9 +572,11 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                               child: NotificationListener<ScrollNotification>(
                                 onNotification: (scrollNotification) {
                                   setState(() {
-                                    _fadeStart = scrollNotification.metrics.pixels / 10;
-                                    _fadeEnd = (scrollNotification.metrics.maxScrollExtent -
-                                        scrollNotification.metrics.pixels) /
+                                    _fadeStart =
+                                        scrollNotification.metrics.pixels / 10;
+                                    _fadeEnd = (scrollNotification
+                                                .metrics.maxScrollExtent -
+                                            scrollNotification.metrics.pixels) /
                                         10;
 
                                     _fadeStart = _fadeStart.clamp(0.0, 1.0);
@@ -531,62 +588,121 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                                   children: [
                                     ListView(
                                       scrollDirection: Axis.horizontal,
-                                      children: List<Widget>.generate(rankingSorts.length, (int index) {
+                                      children: List<Widget>.generate(
+                                          rankingSorts.length, (int index) {
                                         if (index == 9) {
                                           return FutureBuilder(
                                               future: vdaStats,
                                               builder: (context, snapshot) {
                                                 return Container(
-                                                  padding: const EdgeInsets.only(right: 5),
+                                                  padding:
+                                                      const EdgeInsets.only(
+                                                          right: 5),
                                                   child: ChoiceChip(
-                                                    padding: const EdgeInsets.symmetric(horizontal: 5),
-                                                    label: Text(rankingSorts[index],
+                                                    padding: const EdgeInsets
+                                                        .symmetric(
+                                                        horizontal: 5),
+                                                    label: Text(
+                                                        rankingSorts[index],
                                                         style: TextStyle(
-                                                          color: snapshot.connectionState == ConnectionState.done
-                                                              ? Theme.of(context).colorScheme.onSurface
-                                                              : Theme.of(context).colorScheme.onSurfaceVariant,
+                                                          color: snapshot.connectionState ==
+                                                                  ConnectionState
+                                                                      .done
+                                                              ? Theme.of(
+                                                                      context)
+                                                                  .colorScheme
+                                                                  .onSurface
+                                                              : Theme.of(
+                                                                      context)
+                                                                  .colorScheme
+                                                                  .onSurfaceVariant,
                                                         )),
-                                                    selected: sortIndex == index,
+                                                    selected:
+                                                        sortIndex == index,
                                                     shape: RoundedRectangleBorder(
                                                         side: BorderSide(
-                                                            color: snapshot.connectionState == ConnectionState.done
-                                                                ? Theme.of(context).colorScheme.primary
-                                                                : Theme.of(context).colorScheme.tertiary,
+                                                            color: snapshot
+                                                                        .connectionState ==
+                                                                    ConnectionState
+                                                                        .done
+                                                                ? Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .primary
+                                                                : Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .tertiary,
                                                             width: 1.5),
-                                                        borderRadius: BorderRadius.circular(10)),
-                                                    selectedColor: Theme.of(context).colorScheme.primary,
-                                                    chipAnimationStyle: ChipAnimationStyle(
-                                                        enableAnimation: AnimationStyle(duration: Duration.zero),
-                                                        selectAnimation: AnimationStyle(duration: Duration.zero)),
-                                                    onSelected: snapshot.connectionState == ConnectionState.done
+                                                        borderRadius:
+                                                            BorderRadius
+                                                                .circular(10)),
+                                                    selectedColor:
+                                                        Theme.of(context)
+                                                            .colorScheme
+                                                            .primary,
+                                                    chipAnimationStyle:
+                                                        ChipAnimationStyle(
+                                                            enableAnimation:
+                                                                AnimationStyle(
+                                                                    duration:
+                                                                        Duration
+                                                                            .zero),
+                                                            selectAnimation:
+                                                                AnimationStyle(
+                                                                    duration:
+                                                                        Duration
+                                                                            .zero)),
+                                                    onSelected: snapshot
+                                                                .connectionState ==
+                                                            ConnectionState.done
                                                         ? (bool selected) {
-                                                      setState(() {
-                                                        sortIndex = index;
-                                                      });
-                                                    }
+                                                            setState(() {
+                                                              sortIndex = index;
+                                                            });
+                                                          }
                                                         : null,
                                                   ),
                                                 );
                                               });
                                         }
                                         return Container(
-                                          padding: const EdgeInsets.only(right: 5),
+                                          padding:
+                                              const EdgeInsets.only(right: 5),
                                           child: ChoiceChip(
-                                            padding: const EdgeInsets.symmetric(horizontal: 5),
+                                            padding: const EdgeInsets.symmetric(
+                                                horizontal: 5),
                                             label: Text(rankingSorts[index],
                                                 style: TextStyle(
-                                                  color: Theme.of(context).colorScheme.onSurface,
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onSurface,
                                                 )),
                                             selected: sortIndex == index,
                                             shape: RoundedRectangleBorder(
-                                                side:
-                                                BorderSide(color: Theme.of(context).colorScheme.primary, width: 1.5),
-                                                borderRadius: BorderRadius.circular(10)),
-                                            selectedColor: Theme.of(context).colorScheme.primary,
-                                            disabledColor: Theme.of(context).colorScheme.onSurfaceVariant,
-                                            chipAnimationStyle: ChipAnimationStyle(
-                                                enableAnimation: AnimationStyle(duration: Duration.zero),
-                                                selectAnimation: AnimationStyle(duration: Duration.zero)),
+                                                side: BorderSide(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .primary,
+                                                    width: 1.5),
+                                                borderRadius:
+                                                    BorderRadius.circular(10)),
+                                            selectedColor: Theme.of(context)
+                                                .colorScheme
+                                                .primary,
+                                            disabledColor: Theme.of(context)
+                                                .colorScheme
+                                                .onSurfaceVariant,
+                                            chipAnimationStyle:
+                                                ChipAnimationStyle(
+                                                    enableAnimation:
+                                                        AnimationStyle(
+                                                            duration: Duration
+                                                                .zero),
+                                                    selectAnimation:
+                                                        AnimationStyle(
+                                                            duration:
+                                                                Duration.zero)),
                                             onSelected: (bool selected) {
                                               setState(() {
                                                 sortIndex = index;
@@ -602,12 +718,27 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                                         decoration: BoxDecoration(
                                           gradient: LinearGradient(
                                             colors: [
-                                              Theme.of(context).colorScheme.surface,
-                                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                                              Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                                              Theme.of(context).colorScheme.surface,
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface
+                                                  .withValues(alpha: 0),
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface
+                                                  .withValues(alpha: 0),
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ],
-                                            stops: [0.0, 0.05 * _fadeStart, 1 - 0.05 * _fadeEnd, 1.0],
+                                            stops: [
+                                              0.0,
+                                              0.05 * _fadeStart,
+                                              1 - 0.05 * _fadeEnd,
+                                              1.0
+                                            ],
                                           ),
                                         ),
                                       ),
@@ -624,10 +755,12 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                                       size: 30,
                                     ),
                                     onPressed: () async {
-                                      TournamentRankingsFilter updatedFilter = await worldRankingsFilter(
+                                      TournamentRankingsFilter updatedFilter =
+                                          await worldRankingsFilter(
                                         context,
                                         filter,
-                                        prefs.getBool("isTournamentMode") ?? false,
+                                        prefs.getBool("isTournamentMode") ??
+                                            false,
                                       );
                                       setState(() {
                                         filter = updatedFilter;
@@ -640,100 +773,139 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                   : const SliverToBoxAdapter(),
               selectedIndex == 2
                   ? SliverToBoxAdapter(
-                child: Container(
-                  padding: const EdgeInsets.only(left: 23),
-                  height: 50,
-                  child: Flex(
-                    direction: Axis.horizontal,
-                    children: [
-                      Flexible(
-                        flex: 6,
-                        child: NotificationListener<ScrollNotification>(
-                          onNotification: (scrollNotification) {
-                            setState(() {
-                              _fadeStart = scrollNotification.metrics.pixels / 10;
-                              _fadeEnd = (scrollNotification.metrics.maxScrollExtent -
-                                  scrollNotification.metrics.pixels) /
-                                  10;
+                      child: Container(
+                        padding: const EdgeInsets.only(left: 23),
+                        height: 50,
+                        child: Flex(
+                          direction: Axis.horizontal,
+                          children: [
+                            Flexible(
+                              flex: 6,
+                              child: NotificationListener<ScrollNotification>(
+                                onNotification: (scrollNotification) {
+                                  setState(() {
+                                    _fadeStart =
+                                        scrollNotification.metrics.pixels / 10;
+                                    _fadeEnd = (scrollNotification
+                                                .metrics.maxScrollExtent -
+                                            scrollNotification.metrics.pixels) /
+                                        10;
 
-                              _fadeStart = _fadeStart.clamp(0.0, 1.0);
-                              _fadeEnd = _fadeEnd.clamp(0.0, 1.0);
-                            });
-                            return true;
-                          },
-                          child: Stack(
-                            children: [
-                              ListView(
-                                scrollDirection: Axis.horizontal,
-                                children: List<Widget>.generate(skillsSorts.length, (int index) {
-                                  return Container(
-                                    padding: const EdgeInsets.only(right: 5),
-                                    child: ChoiceChip(
-                                      padding: const EdgeInsets.symmetric(horizontal: 5),
-                                      label: Text(skillsSorts[index],
-                                          style: TextStyle(
-                                            color: Theme.of(context).colorScheme.onSurface,
-                                          )),
-                                      selected: sortIndex == index,
-                                      shape: RoundedRectangleBorder(
-                                          side:
-                                          BorderSide(color: Theme.of(context).colorScheme.primary, width: 1.5),
-                                          borderRadius: BorderRadius.circular(10)),
-                                      selectedColor: Theme.of(context).colorScheme.primary,
-                                      disabledColor: Theme.of(context).colorScheme.onSurfaceVariant,
-                                      chipAnimationStyle: ChipAnimationStyle(
-                                          enableAnimation: AnimationStyle(duration: Duration.zero),
-                                          selectAnimation: AnimationStyle(duration: Duration.zero)),
-                                      onSelected: (bool selected) {
-                                        setState(() {
-                                          sortIndex = index;
-                                        });
-                                      },
+                                    _fadeStart = _fadeStart.clamp(0.0, 1.0);
+                                    _fadeEnd = _fadeEnd.clamp(0.0, 1.0);
+                                  });
+                                  return true;
+                                },
+                                child: Stack(
+                                  children: [
+                                    ListView(
+                                      scrollDirection: Axis.horizontal,
+                                      children: List<Widget>.generate(
+                                          skillsSorts.length, (int index) {
+                                        return Container(
+                                          padding:
+                                              const EdgeInsets.only(right: 5),
+                                          child: ChoiceChip(
+                                            padding: const EdgeInsets.symmetric(
+                                                horizontal: 5),
+                                            label: Text(skillsSorts[index],
+                                                style: TextStyle(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onSurface,
+                                                )),
+                                            selected: sortIndex == index,
+                                            shape: RoundedRectangleBorder(
+                                                side: BorderSide(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .primary,
+                                                    width: 1.5),
+                                                borderRadius:
+                                                    BorderRadius.circular(10)),
+                                            selectedColor: Theme.of(context)
+                                                .colorScheme
+                                                .primary,
+                                            disabledColor: Theme.of(context)
+                                                .colorScheme
+                                                .onSurfaceVariant,
+                                            chipAnimationStyle:
+                                                ChipAnimationStyle(
+                                                    enableAnimation:
+                                                        AnimationStyle(
+                                                            duration: Duration
+                                                                .zero),
+                                                    selectAnimation:
+                                                        AnimationStyle(
+                                                            duration:
+                                                                Duration.zero)),
+                                            onSelected: (bool selected) {
+                                              setState(() {
+                                                sortIndex = index;
+                                              });
+                                            },
+                                          ),
+                                        );
+                                      }).toList(),
                                     ),
-                                  );
-                                }).toList(),
-                              ),
-                              IgnorePointer(
-                                ignoring: true,
-                                child: Container(
-                                  decoration: BoxDecoration(
-                                    gradient: LinearGradient(
-                                      colors: [
-                                        Theme.of(context).colorScheme.surface,
-                                        Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                                        Theme.of(context).colorScheme.surface.withValues(alpha: 0),
-                                        Theme.of(context).colorScheme.surface,
-                                      ],
-                                      stops: [0, 0.05 * _fadeStart, 1 - 0.05 * _fadeEnd, 1.0],
+                                    IgnorePointer(
+                                      ignoring: true,
+                                      child: Container(
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(
+                                            colors: [
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface
+                                                  .withValues(alpha: 0),
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface
+                                                  .withValues(alpha: 0),
+                                              Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
+                                            ],
+                                            stops: [
+                                              0,
+                                              0.05 * _fadeStart,
+                                              1 - 0.05 * _fadeEnd,
+                                              1.0
+                                            ],
+                                          ),
+                                        ),
+                                      ),
                                     ),
-                                  ),
+                                  ],
                                 ),
                               ),
-                            ],
-                          ),
+                            ),
+                            Flexible(
+                                flex: 1,
+                                child: IconButton(
+                                    icon: const Icon(
+                                      Icons.filter_list,
+                                      size: 30,
+                                    ),
+                                    onPressed: () async {
+                                      TournamentRankingsFilter updatedFilter =
+                                          await worldRankingsFilter(
+                                        context,
+                                        filter,
+                                        prefs.getBool("isTournamentMode") ??
+                                            false,
+                                      );
+                                      setState(() {
+                                        filter = updatedFilter;
+                                      });
+                                    })),
+                          ],
                         ),
                       ),
-                      Flexible(
-                          flex: 1,
-                          child: IconButton(
-                              icon: const Icon(
-                                Icons.filter_list,
-                                size: 30,
-                              ),
-                              onPressed: () async {
-                                TournamentRankingsFilter updatedFilter = await worldRankingsFilter(
-                                  context,
-                                  filter,
-                                  prefs.getBool("isTournamentMode") ?? false,
-                                );
-                                setState(() {
-                                  filter = updatedFilter;
-                                });
-                              })),
-                    ],
-                  ),
-                ),
-              )
+                    )
                   : const SliverToBoxAdapter(),
               // selectedIndex == 0 &&
               //         division.games != null &&
@@ -820,41 +992,55 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
               // showQualification ? pages[selectedIndex] : SliverToBoxAdapter(),
               selectedIndex == 0 && practice.isNotEmpty
                   ? SliverStickyHeader(
-                      header: ScheduleTab(Theme.of(context).colorScheme.surface, "Practice", () {
+                      header: ScheduleTab(
+                          Theme.of(context).colorScheme.surface, "Practice",
+                          () {
                         setState(() {
                           showPractice = !showPractice;
                         });
                       }, showPractice),
-                      sliver: showPractice ? MatchesView(games: practice) : SliverToBoxAdapter(),
+                      sliver: showPractice
+                          ? MatchesView(games: practice)
+                          : SliverToBoxAdapter(),
                     )
                   : SliverToBoxAdapter(),
 
               selectedIndex == 0 && qualifications.isNotEmpty
                   ? SliverStickyHeader(
                       overlapsContent: false,
-                      header: ScheduleTab(Theme.of(context).colorScheme.surface, "Qualifications", () {
+                      header: ScheduleTab(Theme.of(context).colorScheme.surface,
+                          "Qualifications", () {
                         setState(() {
                           showQualification = !showQualification;
                         });
                       }, showQualification),
-                      sliver: showQualification ? MatchesView(games: qualifications) : SliverToBoxAdapter(),
+                      sliver: showQualification
+                          ? MatchesView(games: qualifications)
+                          : SliverToBoxAdapter(),
                     )
                   : SliverToBoxAdapter(),
 
               selectedIndex == 0 && eliminations.isNotEmpty
                   ? SliverStickyHeader(
-                      header: ScheduleTab(Theme.of(context).colorScheme.surface, "Eliminations", () {
+                      header: ScheduleTab(
+                          Theme.of(context).colorScheme.surface, "Eliminations",
+                          () {
                         setState(() {
                           showElimination = !showElimination;
                         });
                       }, showElimination),
-                      sliver: showElimination ? MatchesView(games: eliminations) : SliverToBoxAdapter(),
+                      sliver: showElimination
+                          ? MatchesView(games: eliminations)
+                          : SliverToBoxAdapter(),
                     )
                   : SliverToBoxAdapter(),
 
-              selectedIndex == 0 && (division.games == null || division.games!.isEmpty)
+              selectedIndex == 0 &&
+                      (division.games == null || division.games!.isEmpty)
                   ? SliverToBoxAdapter(
-                      child: BigErrorMessage(icon: Icons.schedule, message: "Schedule Not Available"),
+                      child: BigErrorMessage(
+                          icon: Icons.schedule,
+                          message: "Schedule Not Available"),
                     )
                   : SliverToBoxAdapter(),
 
@@ -869,7 +1055,8 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
         ));
   }
 
-  Widget ScheduleTab(Color backgroundColor, String title, void Function() onTap, bool variable) {
+  Widget ScheduleTab(Color backgroundColor, String title, void Function() onTap,
+      bool variable) {
     return GestureDetector(
         onTap: onTap,
         behavior: HitTestBehavior.translucent,
@@ -884,7 +1071,9 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
                     title,
                     style: TextStyle(fontSize: 24),
                   ),
-                  Icon(variable ? Icons.keyboard_arrow_down : Icons.keyboard_arrow_right),
+                  Icon(variable
+                      ? Icons.keyboard_arrow_down
+                      : Icons.keyboard_arrow_right),
                 ],
               )),
         ));
@@ -899,8 +1088,9 @@ class _TournamentLoadedScreenState extends State<TournamentLoadedScreen> with Ti
           height: 50,
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color:
-                selectedIndex == index ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.surface,
+            color: selectedIndex == index
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.surface,
           ),
         ),
         IconButton(

--- a/elapse_app/lib/screens/tournament/pages/main/loading.dart
+++ b/elapse_app/lib/screens/tournament/pages/main/loading.dart
@@ -74,7 +74,7 @@ class TournamentLoadingScreen extends StatelessWidget {
     return Stack(
       alignment: Alignment.center,
       children: [
-        Container(
+        SizedBox(
           width: 50,
           height: 50,
         ),

--- a/elapse_app/lib/screens/tournament/pages/main/search_screen.dart
+++ b/elapse_app/lib/screens/tournament/pages/main/search_screen.dart
@@ -8,7 +8,8 @@ import 'package:elapse_app/screens/widgets/rounded_top.dart';
 import 'package:flutter/material.dart';
 
 class SearchScreen extends StatefulWidget {
-  const SearchScreen({super.key, required this.tournament, required this.division});
+  const SearchScreen(
+      {super.key, required this.tournament, required this.division});
 
   final Tournament tournament;
   final Division division;
@@ -40,8 +41,11 @@ class _SearchScreenState extends State<SearchScreen> {
   Widget build(BuildContext context) {
     List<Team> filteredTeams = widget.tournament.teams.where((e) {
       return (e.teamName!.toLowerCase().contains(searchQuery.toLowerCase()) ||
-              e.teamNumber!.toLowerCase().contains(searchQuery.toLowerCase())) &&
-          ((widget.division.teamStats != null && widget.division.teamStats![e.id] != null) ||
+              e.teamNumber!
+                  .toLowerCase()
+                  .contains(searchQuery.toLowerCase())) &&
+          ((widget.division.teamStats != null &&
+                  widget.division.teamStats![e.id] != null) ||
               widget.division.teamStats?.isEmpty == true);
     }).toList();
     List<Game> filteredGames;
@@ -55,16 +59,21 @@ class _SearchScreenState extends State<SearchScreen> {
         if (searchQuery.isEmpty) {
           return true;
         }
-        bool gameContainsSearchQuery = e.blueAlliancePreview![0].teamNumber.contains(searchQuery.toUpperCase()) ||
-            e.blueAlliancePreview![1].teamNumber.contains(searchQuery.toUpperCase()) ||
-            e.redAlliancePreview![0].teamNumber.contains(searchQuery.toUpperCase()) ||
-            e.redAlliancePreview![1].teamNumber.contains(searchQuery.toUpperCase()) ||
+        bool gameContainsSearchQuery = e.blueAlliancePreview![0].teamNumber
+                .contains(searchQuery.toUpperCase()) ||
+            e.blueAlliancePreview![1].teamNumber
+                .contains(searchQuery.toUpperCase()) ||
+            e.redAlliancePreview![0].teamNumber
+                .contains(searchQuery.toUpperCase()) ||
+            e.redAlliancePreview![1].teamNumber
+                .contains(searchQuery.toUpperCase()) ||
             e.gameName.contains(searchQuery.toUpperCase());
 
-        bool gameContainsFilteredTeam = teamNumbers.contains(e.blueAlliancePreview![0].teamNumber) ||
-            teamNumbers.contains(e.blueAlliancePreview![1].teamNumber) ||
-            teamNumbers.contains(e.redAlliancePreview![0].teamNumber) ||
-            teamNumbers.contains(e.redAlliancePreview![1].teamNumber);
+        bool gameContainsFilteredTeam =
+            teamNumbers.contains(e.blueAlliancePreview![0].teamNumber) ||
+                teamNumbers.contains(e.blueAlliancePreview![1].teamNumber) ||
+                teamNumbers.contains(e.redAlliancePreview![0].teamNumber) ||
+                teamNumbers.contains(e.redAlliancePreview![1].teamNumber);
 
         return gameContainsSearchQuery || gameContainsFilteredTeam;
       }).toList();
@@ -100,7 +109,8 @@ class _SearchScreenState extends State<SearchScreen> {
                               Spacer(),
                               Flex(
                                 direction: Axis.horizontal,
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
                                   Flexible(
                                       flex: 1,
@@ -122,31 +132,40 @@ class _SearchScreenState extends State<SearchScreen> {
                                           searchQuery = value;
                                         });
                                       },
-                                      cursorColor: Theme.of(context).colorScheme.secondary,
+                                      cursorColor: Theme.of(context)
+                                          .colorScheme
+                                          .secondary,
                                       decoration: InputDecoration(
-                                          hintText: "Search ${widget.division.name}", border: InputBorder.none),
+                                          hintText:
+                                              "Search ${widget.division.name}",
+                                          border: InputBorder.none),
                                     ),
                                   ),
                                 ],
                               ),
                               Spacer(),
                               if (constraints.maxHeight - 135 + 45 > 0)
-                                Container(
-                                  height: containerHeight > 130 ? 45 : containerHeight - 130 + 45,
+                                SizedBox(
+                                  height: containerHeight > 130
+                                      ? 45
+                                      : containerHeight - 130 + 45,
                                   child: Flex(
                                     direction: Axis.horizontal,
                                     children: [
                                       Flexible(
                                         flex: 1,
-                                        child: FilterButton(0, constraints.maxHeight, "All"),
+                                        child: FilterButton(
+                                            0, constraints.maxHeight, "All"),
                                       ),
                                       Flexible(
                                         flex: 1,
-                                        child: FilterButton(1, constraints.maxHeight, "Teams"),
+                                        child: FilterButton(
+                                            1, constraints.maxHeight, "Teams"),
                                       ),
                                       Flexible(
                                         flex: 1,
-                                        child: FilterButton(2, constraints.maxHeight, "Games"),
+                                        child: FilterButton(
+                                            2, constraints.maxHeight, "Games"),
                                       ),
                                     ],
                                   ),
@@ -200,7 +219,8 @@ class _SearchScreenState extends State<SearchScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text('"$searchQuery" in teams', style: TextStyle(fontSize: 16)),
+                        Text('"$searchQuery" in teams',
+                            style: TextStyle(fontSize: 16)),
                         Divider(
                           color: Theme.of(context).colorScheme.surfaceDim,
                           thickness: 1.5,
@@ -217,24 +237,31 @@ class _SearchScreenState extends State<SearchScreen> {
                         (context, index) {
                           final team = filteredTeams[index];
                           return Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 23.0),
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 23.0),
                             child: Column(
                               children: [
                                 widget.division.teamStats![team.id] == null
                                     ? EmptyRanking(
                                         teamName: team.teamNumber ?? "",
                                         teamID: team.id,
-                                        allianceColor: Theme.of(context).colorScheme.onSurface)
+                                        allianceColor: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface)
                                     : RankingsWidget(
                                         teamNumber: team.teamNumber!,
                                         teamName: team.teamName!,
                                         teamID: team.id,
-                                        allianceColor: Theme.of(context).colorScheme.onSurface,
+                                        allianceColor: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface,
                                       ),
                                 index != filteredTeams.length - 1
                                     ? Divider(
                                         height: 3,
-                                        color: Theme.of(context).colorScheme.surfaceDim,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceDim,
                                       )
                                     : Container(),
                               ],
@@ -245,7 +272,9 @@ class _SearchScreenState extends State<SearchScreen> {
                       ),
                     )
                   : const SliverToBoxAdapter(
-                      child: SizedBox(height: 15, child: Center(child: Text("No results found"))))
+                      child: SizedBox(
+                          height: 15,
+                          child: Center(child: Text("No results found"))))
               : const SliverToBoxAdapter(),
           SliverToBoxAdapter(
             child: selectedIndex == 0
@@ -261,7 +290,8 @@ class _SearchScreenState extends State<SearchScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text('"$searchQuery" in games', style: TextStyle(fontSize: 16)),
+                        Text('"$searchQuery" in games',
+                            style: TextStyle(fontSize: 16)),
                         Divider(
                           color: Theme.of(context).colorScheme.surfaceDim,
                           thickness: 1.5,
@@ -278,7 +308,8 @@ class _SearchScreenState extends State<SearchScreen> {
                         (context, index) {
                           final game = filteredGames[index];
                           return Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 23.0),
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 23.0),
                             child: Column(
                               children: [
                                 GameWidget(
@@ -287,7 +318,9 @@ class _SearchScreenState extends State<SearchScreen> {
                                 index != widget.division.games!.length - 1
                                     ? Divider(
                                         height: 3,
-                                        color: Theme.of(context).colorScheme.surfaceDim,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceDim,
                                       )
                                     : Container(),
                               ],
@@ -298,7 +331,9 @@ class _SearchScreenState extends State<SearchScreen> {
                       ),
                     )
                   : const SliverToBoxAdapter(
-                      child: SizedBox(height: 15, child: Center(child: Text("No results found"))))
+                      child: SizedBox(
+                          height: 15,
+                          child: Center(child: Text("No results found"))))
               : const SliverToBoxAdapter(),
           const SliverToBoxAdapter(child: SizedBox(height: 40)),
         ],
@@ -334,38 +369,41 @@ class _SearchScreenState extends State<SearchScreen> {
       },
       child: AnimatedContainer(
         curve: Curves.fastOutSlowIn,
-        duration: const Duration(milliseconds: 300), // Duration of the animation
+        duration:
+            const Duration(milliseconds: 300), // Duration of the animation
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: selectedIndex == buttonIndex
-              ? selectedContainerColor.withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)
-              : unselectedContainerColor.withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+              ? selectedContainerColor.withValues(
+                  alpha:
+                      ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40)
+              : unselectedContainerColor.withValues(
+                  alpha:
+                      ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
           border: buttonIndex == 1
               ? Border.symmetric(
                   horizontal: BorderSide(
                     width: 1.5,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .primary
-                        .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+                    color: Theme.of(context).colorScheme.primary.withValues(
+                        alpha: ((maxHeight - 85) / 40) > 1
+                            ? 1
+                            : (maxHeight - 85) / 40),
                   ),
                 )
               : Border.all(
                   width: 1.5,
-                  color: Theme.of(context)
-                      .colorScheme
-                      .primary
-                      .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+                  color: Theme.of(context).colorScheme.primary.withValues(
+                      alpha: ((maxHeight - 85) / 40) > 1
+                          ? 1
+                          : (maxHeight - 85) / 40),
                 ),
           borderRadius: borderRadius,
         ),
         child: Text(
           text,
           style: TextStyle(
-            color: Theme.of(context)
-                .colorScheme
-                .secondary
-                .withValues(alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
+            color: Theme.of(context).colorScheme.secondary.withValues(
+                alpha: ((maxHeight - 85) / 40) > 1 ? 1 : (maxHeight - 85) / 40),
             fontSize: 14,
             fontWeight: FontWeight.w500,
           ),

--- a/elapse_app/lib/screens/tournament/pages/rankings/rankings.dart
+++ b/elapse_app/lib/screens/tournament/pages/rankings/rankings.dart
@@ -37,43 +37,60 @@ class RankingsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Tournament tournament = loadTournament(prefs.getString("recently-opened-tournament"));
+    Tournament tournament =
+        loadTournament(prefs.getString("recently-opened-tournament"));
 
     List<Team> teams = tournament.teams;
     List<TeamPreview> savedTeams = [];
     if (filter.saved) {
       final String savedTeam = prefs.getString("savedTeam") ?? "";
-      TeamPreview savedTeamPreview =
-          TeamPreview(teamID: jsonDecode(savedTeam)["teamID"], teamNumber: jsonDecode(savedTeam)["teamNumber"]);
+      TeamPreview savedTeamPreview = TeamPreview(
+          teamID: jsonDecode(savedTeam)["teamID"],
+          teamNumber: jsonDecode(savedTeam)["teamNumber"]);
       List<String> savedTeamsString = prefs.getStringList("savedTeams") ?? [];
       savedTeams.add(savedTeamPreview);
       savedTeams.addAll(savedTeamsString
-          .map((e) => TeamPreview(teamID: jsonDecode(e)["teamID"], teamNumber: jsonDecode(e)["teamNumber"]))
+          .map((e) => TeamPreview(
+              teamID: jsonDecode(e)["teamID"],
+              teamNumber: jsonDecode(e)["teamNumber"]))
           .toList());
-      teams = tournament.teams.where((element) => savedTeams.any((element2) => element2.teamID == element.id)).toList();
+      teams = tournament.teams
+          .where((element) =>
+              savedTeams.any((element2) => element2.teamID == element.id))
+          .toList();
     } else {
       teams = tournament.teams;
     }
 
     List<TeamPreview> scoutedTeams = [];
     if (filter.scouted) {
-      teams = tournament.teams.where((e) => scoutedTeams.any((e2) => e2.teamID == e.id)).toList();
+      teams = tournament.teams
+          .where((e) => scoutedTeams.any((e2) => e2.teamID == e.id))
+          .toList();
     }
 
-    List<TeamPreview> pickListTeams = (prefs.getStringList("picklist") ?? []).map((e) => loadTeamPreview(e)).toList();
+    List<TeamPreview> pickListTeams = (prefs.getStringList("picklist") ?? [])
+        .map((e) => loadTeamPreview(e))
+        .toList();
     if (filter.onPicklist) {
-      teams = tournament.teams.where((e) => pickListTeams.any((e2) => e2.teamID == e.id)).toList();
+      teams = tournament.teams
+          .where((e) => pickListTeams.any((e2) => e2.teamID == e.id))
+          .toList();
     }
 
-    Map<int, TeamStats>? rankings = tournament.divisions[divisionIndex].teamStats;
+    Map<int, TeamStats>? rankings =
+        tournament.divisions[divisionIndex].teamStats;
 
     if (rankings == null || rankings.isEmpty) {
       return SliverToBoxAdapter(
-        child: BigErrorMessage(icon: Icons.format_list_numbered_outlined, message: "Rankings not available"),
+        child: BigErrorMessage(
+            icon: Icons.format_list_numbered_outlined,
+            message: "Rankings not available"),
       );
     }
 
-    List<Team> divisionTeams = teams.where((e) => rankings[e.id] != null).toList();
+    List<Team> divisionTeams =
+        teams.where((e) => rankings[e.id] != null).toList();
     if (sort == "Rank") {
       divisionTeams.sort((a, b) {
         return rankings[a.id]!.rank.compareTo(rankings[b.id]!.rank);
@@ -110,20 +127,21 @@ class RankingsPage extends StatelessWidget {
       divisionTeams.sort((a, b) {
         return worldSkills
             .singleWhere((e) => e.teamId == b.id, orElse: () {
-              return WorldSkillsStats(teamId: b.id, teamNum: b.teamNumber ?? "");
+              return WorldSkillsStats(
+                  teamId: b.id, teamNum: b.teamNumber ?? "");
             })
             .score
-            .compareTo(worldSkills.singleWhere((e) => e.teamId == a.id, orElse: () {
-              return WorldSkillsStats(teamId: b.id, teamNum: b.teamNumber ?? "");
+            .compareTo(
+                worldSkills.singleWhere((e) => e.teamId == a.id, orElse: () {
+              return WorldSkillsStats(
+                  teamId: b.id, teamNum: b.teamNumber ?? "");
             }).score);
       });
     } else if (sort == "TrueSkill") {
       if (vda != null) {
         divisionTeams.sort((a, b) {
-          return vda!
-                  .singleWhere((e) => e.id == b.id)
-                  .trueSkill
-                  ?.compareTo(vda!.singleWhere((e) => e.id == a.id).trueSkill ?? 0) ??
+          return vda!.singleWhere((e) => e.id == b.id).trueSkill?.compareTo(
+                  vda!.singleWhere((e) => e.id == a.id).trueSkill ?? 0) ??
               0;
         });
       } else {
@@ -163,7 +181,8 @@ class RankingsPage extends StatelessWidget {
                 sort: sort,
                 allianceColor: Theme.of(context).colorScheme.onSurface,
                 skills: skills[team.id],
-                worldSkills: worldSkills.firstWhereOrNull((e) => e.teamId == team.id),
+                worldSkills:
+                    worldSkills.firstWhereOrNull((e) => e.teamId == team.id),
                 vda: vda?.firstWhereOrNull((e) => e.id == team.id),
               ),
               Divider(

--- a/elapse_app/lib/screens/tournament/pages/rankings/rankings_filter.dart
+++ b/elapse_app/lib/screens/tournament/pages/rankings/rankings_filter.dart
@@ -13,9 +13,7 @@ class TournamentRankingsFilter {
 }
 
 Future<TournamentRankingsFilter> worldRankingsFilter(
-    BuildContext context,
-    TournamentRankingsFilter filter,
-    bool inTM) async {
+    BuildContext context, TournamentRankingsFilter filter, bool inTM) async {
   final DraggableScrollableController dra = DraggableScrollableController();
 
   return await showModalBottomSheet<TournamentRankingsFilter>(
@@ -57,29 +55,29 @@ Future<TournamentRankingsFilter> worldRankingsFilter(
                                   fontWeight: FontWeight.w500,
                                 ),
                               ),
-                                  filter.saved ||
-                                  filter.onPicklist ||
-                                  filter.scouted
+                              filter.saved ||
+                                      filter.onPicklist ||
+                                      filter.scouted
                                   ? TextButton(
-                                child: Text("Clear",
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      height: 1,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .secondary,
-                                      fontWeight: FontWeight.w400,
-                                    )),
-                                onPressed: () {
-                                  setModalState(() {
-                                    filter = TournamentRankingsFilter();
-                                  });
-                                },
-                              )
+                                      child: Text("Clear",
+                                          style: TextStyle(
+                                            fontSize: 16,
+                                            height: 1,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .secondary,
+                                            fontWeight: FontWeight.w400,
+                                          )),
+                                      onPressed: () {
+                                        setModalState(() {
+                                          filter = TournamentRankingsFilter();
+                                        });
+                                      },
+                                    )
                                   : TextButton(
-                                child: const SizedBox(),
-                                onPressed: () {},
-                              ),
+                                      child: const SizedBox(),
+                                      onPressed: () {},
+                                    ),
                             ]),
                         const SizedBox(
                           height: 20,
@@ -94,7 +92,7 @@ Future<TournamentRankingsFilter> worldRankingsFilter(
                             border: Border.all(
                                 color: Theme.of(context).colorScheme.primary),
                             borderRadius:
-                            const BorderRadius.all(Radius.circular(100)),
+                                const BorderRadius.all(Radius.circular(100)),
                           ),
                           child: InkWell(
                             child: Row(
@@ -110,8 +108,8 @@ Future<TournamentRankingsFilter> worldRankingsFilter(
                                     ]),
                                 filter.saved
                                     ? const Row(children: [
-                                  Icon(Icons.check),
-                                ])
+                                        Icon(Icons.check),
+                                      ])
                                     : const SizedBox(),
                               ],
                             ),
@@ -124,50 +122,50 @@ Future<TournamentRankingsFilter> worldRankingsFilter(
                         ),
                         inTM ? const SizedBox(height: 12) : const SizedBox(),
                         inTM
-                        ? Container(
-                          height: 50,
-                          padding:
-                          const EdgeInsets.only(left: 20, right: 20),
-                          decoration: BoxDecoration(
-                            color: filter.onPicklist
-                                ? Theme.of(context).colorScheme.primary
-                                : Theme.of(context).colorScheme.surface,
-                            border: Border.all(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .primary),
-                            borderRadius: const BorderRadius.all(
-                                Radius.circular(100)),
-                          ),
-                          child: InkWell(
-                            child: Row(
-                              mainAxisAlignment:
-                              MainAxisAlignment.spaceBetween,
-                              children: [
-                                const Row(
+                            ? Container(
+                                height: 50,
+                                padding:
+                                    const EdgeInsets.only(left: 20, right: 20),
+                                decoration: BoxDecoration(
+                                  color: filter.onPicklist
+                                      ? Theme.of(context).colorScheme.primary
+                                      : Theme.of(context).colorScheme.surface,
+                                  border: Border.all(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .primary),
+                                  borderRadius: const BorderRadius.all(
+                                      Radius.circular(100)),
+                                ),
+                                child: InkWell(
+                                  child: Row(
                                     mainAxisAlignment:
-                                    MainAxisAlignment.start,
+                                        MainAxisAlignment.spaceBetween,
                                     children: [
-                                      Icon(Icons.person_add_alt),
-                                      SizedBox(width: 10),
-                                      Text("On Picklist",
-                                          style: TextStyle(fontSize: 16)),
-                                    ]),
-                                filter.onPicklist
-                                    ? const Row(children: [
-                                  Icon(Icons.check),
-                                ])
-                                    : const SizedBox(),
-                              ],
-                            ),
-                            onTap: () {
-                              setModalState(() {
-                                filter.onPicklist = !filter.onPicklist;
-                              });
-                            },
-                          ),
-                        )
-                        : const SizedBox(),
+                                      const Row(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.start,
+                                          children: [
+                                            Icon(Icons.person_add_alt),
+                                            SizedBox(width: 10),
+                                            Text("On Picklist",
+                                                style: TextStyle(fontSize: 16)),
+                                          ]),
+                                      filter.onPicklist
+                                          ? const Row(children: [
+                                              Icon(Icons.check),
+                                            ])
+                                          : const SizedBox(),
+                                    ],
+                                  ),
+                                  onTap: () {
+                                    setModalState(() {
+                                      filter.onPicklist = !filter.onPicklist;
+                                    });
+                                  },
+                                ),
+                              )
+                            : const SizedBox(),
                         const SizedBox(height: 12),
                         Container(
                           height: 50,
@@ -179,7 +177,7 @@ Future<TournamentRankingsFilter> worldRankingsFilter(
                             border: Border.all(
                                 color: Theme.of(context).colorScheme.primary),
                             borderRadius:
-                            const BorderRadius.all(Radius.circular(100)),
+                                const BorderRadius.all(Radius.circular(100)),
                           ),
                           child: InkWell(
                             child: Row(
@@ -195,8 +193,8 @@ Future<TournamentRankingsFilter> worldRankingsFilter(
                                     ]),
                                 filter.scouted
                                     ? const Row(children: [
-                                  Icon(Icons.check),
-                                ])
+                                        Icon(Icons.check),
+                                      ])
                                     : const SizedBox(),
                               ],
                             ),

--- a/elapse_app/lib/screens/tournament/pages/rankings/rankings_widget.dart
+++ b/elapse_app/lib/screens/tournament/pages/rankings/rankings_widget.dart
@@ -36,11 +36,13 @@ class RankingsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Tournament tournament = loadTournament(prefs.getString("recently-opened-tournament"));
+    Tournament tournament =
+        loadTournament(prefs.getString("recently-opened-tournament"));
 
     int divisionIndex = getTeamDivisionIndex(tournament.divisions, teamID);
 
-    Map<int, TeamStats> rankings = tournament.divisions[divisionIndex].teamStats!;
+    Map<int, TeamStats> rankings =
+        tournament.divisions[divisionIndex].teamStats!;
     TeamStats stats = rankings[teamID]!;
 
     String val1 = "${stats.wins}-${stats.losses}-${stats.ties}",
@@ -106,7 +108,11 @@ class RankingsWidget extends StatelessWidget {
                     child: Text(
                       "${rank ?? stats.rank}",
                       maxLines: 1,
-                      style: TextStyle(fontSize: 24, fontWeight: FontWeight.w600, height: 1, color: allianceColor),
+                      style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w600,
+                          height: 1,
+                          color: allianceColor),
                       textAlign: TextAlign.start,
                     ),
                   ),
@@ -188,7 +194,11 @@ class RankingsWidget extends StatelessWidget {
 }
 
 class EmptyRanking extends StatelessWidget {
-  const EmptyRanking({super.key, required this.teamName, required this.teamID, required this.allianceColor});
+  const EmptyRanking(
+      {super.key,
+      required this.teamName,
+      required this.teamID,
+      required this.allianceColor});
 
   final String teamName;
   final int teamID;
@@ -212,7 +222,11 @@ class EmptyRanking extends StatelessWidget {
         height: 72,
         child: Text(
           teamName,
-          style: TextStyle(fontSize: 40, height: 1, fontWeight: FontWeight.w400, color: allianceColor),
+          style: TextStyle(
+              fontSize: 40,
+              height: 1,
+              fontWeight: FontWeight.w400,
+              color: allianceColor),
         ),
       ),
     );

--- a/elapse_app/lib/screens/tournament/pages/rankings/tournament_stats_page.dart
+++ b/elapse_app/lib/screens/tournament/pages/rankings/tournament_stats_page.dart
@@ -7,8 +7,10 @@ import 'package:elapse_app/screens/team_screen/team_screen.dart';
 import 'package:elapse_app/screens/tournament/pages/schedule/game_widget.dart';
 import 'package:flutter/material.dart';
 
-Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNumber, String teamName) {
-  Tournament tournament = loadTournament(prefs.getString("recently-opened-tournament"));
+Future<void> tournamentStatsPage(
+    BuildContext context, int teamID, String teamNumber, String teamName) {
+  Tournament tournament =
+      loadTournament(prefs.getString("recently-opened-tournament"));
 
   int divisionIndex = getTeamDivisionIndex(tournament.divisions, teamID);
 
@@ -67,11 +69,15 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                         children: [
                           Text(
                             "$teamNumber Stats",
-                            style: const TextStyle(fontSize: 24, height: 1, fontWeight: FontWeight.w500),
+                            style: const TextStyle(
+                                fontSize: 24,
+                                height: 1,
+                                fontWeight: FontWeight.w500),
                           ),
                           Text(
                             teamName,
-                            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w300),
+                            style: const TextStyle(
+                                fontSize: 16, fontWeight: FontWeight.w300),
                           )
                         ]),
                     GestureDetector(
@@ -88,7 +94,9 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                       },
                       child: Text(
                         "View More",
-                        style: TextStyle(fontSize: 16, color: Theme.of(context).colorScheme.secondary),
+                        style: TextStyle(
+                            fontSize: 16,
+                            color: Theme.of(context).colorScheme.secondary),
                       ),
                     )
                   ],
@@ -99,7 +107,8 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                 Container(
                   height: 300,
                   decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(18), color: Theme.of(context).colorScheme.primary),
+                      borderRadius: BorderRadius.circular(18),
+                      color: Theme.of(context).colorScheme.primary),
                   padding: EdgeInsets.all(18),
                   child: Column(children: [
                     Row(
@@ -111,7 +120,8 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                           children: [
                             Text(
                               "$rank",
-                              style: const TextStyle(fontSize: 64, letterSpacing: -2, height: 1),
+                              style: const TextStyle(
+                                  fontSize: 64, letterSpacing: -2, height: 1),
                             ),
                             const SizedBox(
                               height: 4,
@@ -132,7 +142,10 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                                 children: [
                                   Text(
                                     "${teamStats.wp}",
-                                    style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500, height: 1),
+                                    style: const TextStyle(
+                                        fontSize: 24,
+                                        fontWeight: FontWeight.w500,
+                                        height: 1),
                                   ),
                                   const SizedBox(height: 4),
                                   const Text(
@@ -146,7 +159,10 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                                 children: [
                                   Text(
                                     "${teamStats.ap}",
-                                    style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500, height: 1),
+                                    style: const TextStyle(
+                                        fontSize: 24,
+                                        fontWeight: FontWeight.w500,
+                                        height: 1),
                                   ),
                                   const SizedBox(height: 4),
                                   const Text(
@@ -160,7 +176,10 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                                 children: [
                                   Text(
                                     "${teamStats.sp}",
-                                    style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500, height: 1),
+                                    style: const TextStyle(
+                                        fontSize: 24,
+                                        fontWeight: FontWeight.w500,
+                                        height: 1),
                                   ),
                                   const SizedBox(height: 4),
                                   const Text(
@@ -183,7 +202,9 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                           "Record",
                           style: TextStyle(fontSize: 24),
                         ),
-                        Text("$wins-$losses-$ties", style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500))
+                        Text("$wins-$losses-$ties",
+                            style: const TextStyle(
+                                fontSize: 24, fontWeight: FontWeight.w500))
                       ],
                     ),
                     const SizedBox(
@@ -196,8 +217,10 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                           "Skills Rank",
                           style: TextStyle(fontSize: 24),
                         ),
-                        Text("${tournament.tournamentSkills![teamID]?.rank ?? "N/A"}",
-                            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500))
+                        Text(
+                            "${tournament.tournamentSkills![teamID]?.rank ?? "N/A"}",
+                            style: const TextStyle(
+                                fontSize: 24, fontWeight: FontWeight.w500))
                       ],
                     ),
                     const SizedBox(
@@ -218,7 +241,8 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                             children: [
                               Text(
                                 "$awp",
-                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 16, fontWeight: FontWeight.w500),
                               ),
                               const Text(
                                 "AWP",
@@ -234,7 +258,8 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                             children: [
                               Text(
                                 "${(awpRate * 100).toStringAsFixed(1)}%",
-                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                style: const TextStyle(
+                                    fontSize: 16, fontWeight: FontWeight.w500),
                               ),
                               const Text(
                                 "AWP %",
@@ -250,7 +275,9 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                               children: [
                                 Text(
                                   "$opr",
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
                                 const Text(
                                   "OPR",
@@ -266,7 +293,9 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                               children: [
                                 Text(
                                   "$dpr",
-                                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                  style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500),
                                 ),
                                 Text(
                                   "DPR",
@@ -277,16 +306,20 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                             const SizedBox(
                               width: 18,
                             ),
-                            Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                              Text(
-                                "$ccwm",
-                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-                              ),
-                              Text(
-                                "CCWM",
-                                style: TextStyle(fontSize: 16),
-                              )
-                            ])
+                            Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    "$ccwm",
+                                    style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w500),
+                                  ),
+                                  Text(
+                                    "CCWM",
+                                    style: TextStyle(fontSize: 16),
+                                  )
+                                ])
                           ],
                         ),
                       ],
@@ -298,7 +331,7 @@ Future<void> tournamentStatsPage(BuildContext context, int teamID, String teamNu
                 ),
                 const Text(
                   "Matches",
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 24,
                   ),
                 ),

--- a/elapse_app/lib/screens/tournament/pages/schedule/game_screen.dart
+++ b/elapse_app/lib/screens/tournament/pages/schedule/game_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:elapse_app/aesthetics/color_pallete.dart';
 import 'package:elapse_app/aesthetics/color_schemes.dart';
 import 'package:elapse_app/classes/Team/team.dart';
@@ -27,9 +25,11 @@ class GameScreen extends StatefulWidget {
 
 class _GameScreenState extends State<GameScreen> {
   List<Team> teams = [];
+  @override
   void initState() {
     super.initState();
-    Tournament tournament = loadTournament(prefs.getString("recently-opened-tournament"));
+    Tournament tournament =
+        loadTournament(prefs.getString("recently-opened-tournament"));
     teams = tournament.teams;
   }
 
@@ -50,7 +50,8 @@ class _GameScreenState extends State<GameScreen> {
     }
 
     String status = "Not played";
-    if ((widget.game.redScore != 0 && widget.game.blueScore != 0) || widget.game.startedTime != null) {
+    if ((widget.game.redScore != 0 && widget.game.blueScore != 0) ||
+        widget.game.startedTime != null) {
       status = "Played";
     }
 
@@ -97,7 +98,9 @@ class _GameScreenState extends State<GameScreen> {
       body: CustomScrollView(
         slivers: [
           ElapseAppBar(
-            title: Text("Game Info", style: const TextStyle(fontSize: 24, height: 1, fontWeight: FontWeight.w600)),
+            title: Text("Game Info",
+                style: const TextStyle(
+                    fontSize: 24, height: 1, fontWeight: FontWeight.w600)),
             backNavigation: true,
           ),
           const RoundedTop(),
@@ -107,7 +110,9 @@ class _GameScreenState extends State<GameScreen> {
               delegate: SliverChildListDelegate([
                 Container(
                   height: 220,
-                  decoration: BoxDecoration(color: gameColor, borderRadius: BorderRadius.circular(18)),
+                  decoration: BoxDecoration(
+                      color: gameColor,
+                      borderRadius: BorderRadius.circular(18)),
                   child: Padding(
                     padding: const EdgeInsets.all(18.0),
                     child: Column(
@@ -127,7 +132,8 @@ class _GameScreenState extends State<GameScreen> {
                                 ),
                                 Text(
                                   status,
-                                  style: const TextStyle(fontSize: 16, height: 1),
+                                  style:
+                                      const TextStyle(fontSize: 16, height: 1),
                                 ),
                               ],
                             ),
@@ -135,19 +141,35 @@ class _GameScreenState extends State<GameScreen> {
                         ),
                         Column(
                           children: [
-                            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-                              const Text("Start Time", style: TextStyle(fontSize: 24, height: 1)),
-                              Text(twelveHour(time),
-                                  style: const TextStyle(fontSize: 24, height: 1, fontWeight: FontWeight.w500))
-                            ]),
+                            Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  const Text("Start Time",
+                                      style:
+                                          TextStyle(fontSize: 24, height: 1)),
+                                  Text(twelveHour(time),
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          height: 1,
+                                          fontWeight: FontWeight.w500))
+                                ]),
                             SizedBox(
                               height: 20,
                             ),
-                            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-                              const Text("Field", style: TextStyle(fontSize: 24, height: 1)),
-                              Text(widget.game.fieldName ?? "",
-                                  style: const TextStyle(fontSize: 24, height: 1, fontWeight: FontWeight.w500))
-                            ])
+                            Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  const Text("Field",
+                                      style:
+                                          TextStyle(fontSize: 24, height: 1)),
+                                  Text(widget.game.fieldName ?? "",
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          height: 1,
+                                          fontWeight: FontWeight.w500))
+                                ])
                           ],
                         ),
                       ],
@@ -198,9 +220,12 @@ class _GameScreenState extends State<GameScreen> {
                                       teamID: e.teamID,
                                       teamNumber: e.teamNumber,
                                       teamName: teamName,
-                                      allianceColor: colorPallete.redAllianceText),
+                                      allianceColor:
+                                          colorPallete.redAllianceText),
                                   Divider(
-                                    color: Theme.of(context).colorScheme.surfaceDim,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceDim,
                                     thickness: 1,
                                   )
                                 ],
@@ -256,9 +281,12 @@ class _GameScreenState extends State<GameScreen> {
                                       teamID: e.teamID,
                                       teamNumber: e.teamNumber,
                                       teamName: teamName,
-                                      allianceColor: colorPallete.blueAllianceText),
+                                      allianceColor:
+                                          colorPallete.blueAllianceText),
                                   Divider(
-                                    color: Theme.of(context).colorScheme.surfaceDim,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceDim,
                                     thickness: 1,
                                   )
                                 ],

--- a/elapse_app/lib/screens/tournament/pages/schedule/game_widget.dart
+++ b/elapse_app/lib/screens/tournament/pages/schedule/game_widget.dart
@@ -1,11 +1,7 @@
 import 'package:elapse_app/aesthetics/color_pallete.dart';
 import 'package:elapse_app/aesthetics/color_schemes.dart';
-import 'package:elapse_app/classes/Tournament/division.dart';
 import 'package:elapse_app/classes/Tournament/game.dart';
-import 'package:elapse_app/classes/Tournament/tournament.dart';
-import 'package:elapse_app/classes/Tournament/tournament_mode_functions.dart';
 import 'package:elapse_app/extras/twelve_hour.dart';
-import 'package:elapse_app/main.dart';
 import 'package:elapse_app/screens/tournament/pages/schedule/game_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -66,17 +62,22 @@ class GameWidget extends StatelessWidget {
     if (isAllianceColoured == false) {
       gameColor = Theme.of(context).colorScheme.onSurface;
     } else {
-      if (game.redAlliancePreview!.any((element) => element.teamNumber == teamName)) {
+      if (game.redAlliancePreview!
+          .any((element) => element.teamNumber == teamName)) {
         gameColor = colorPallete.redAllianceText;
-      } else if (game.blueAlliancePreview!.any((element) => element.teamNumber == teamName)) {
+      } else if (game.blueAlliancePreview!
+          .any((element) => element.teamNumber == teamName)) {
         gameColor = colorPallete.blueAllianceText;
       }
     }
 
-    if (winningAlliance == "red" && game.redAlliancePreview!.any((element) => element.teamNumber == teamName)) {
+    if (winningAlliance == "red" &&
+        game.redAlliancePreview!
+            .any((element) => element.teamNumber == teamName)) {
       gameColor = colorPallete.greenText;
     } else if (winningAlliance == "blue" &&
-        game.blueAlliancePreview!.any((element) => element.teamNumber == teamName)) {
+        game.blueAlliancePreview!
+            .any((element) => element.teamNumber == teamName)) {
       gameColor = colorPallete.greenText;
     } else if (winningAlliance != "none" && teamName != null) {
       gameColor = colorPallete.redAllianceText;
@@ -119,9 +120,10 @@ class GameWidget extends StatelessWidget {
           ));
     }
 
-    Color timeColor = Theme.of(context).colorScheme.brightness == Brightness.dark
-        ? const Color.fromARGB(255, 168, 168, 168)
-        : const Color.fromARGB(255, 118, 118, 118);
+    Color timeColor =
+        Theme.of(context).colorScheme.brightness == Brightness.dark
+            ? const Color.fromARGB(255, 168, 168, 168)
+            : const Color.fromARGB(255, 118, 118, 118);
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -162,12 +164,15 @@ class GameWidget extends StatelessWidget {
                       children: [
                         Text(
                           time,
-                          style: TextStyle(fontSize: 16, height: 1, color: timeColor),
+                          style: TextStyle(
+                              fontSize: 16, height: 1, color: timeColor),
                           maxLines: 1,
                         ),
-                        (game.redScore != 0 && game.blueScore != 0) || game.startedTime != null
+                        (game.redScore != 0 && game.blueScore != 0) ||
+                                game.startedTime != null
                             ? Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
                                   Text(
                                     game.redScore.toString(),
@@ -179,7 +184,10 @@ class GameWidget extends StatelessWidget {
                                   ),
                                   Text("-",
                                       style: TextStyle(
-                                          color: timeColor, fontSize: 16, fontWeight: FontWeight.w500, height: 1)),
+                                          color: timeColor,
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500,
+                                          height: 1)),
                                   Text(
                                     game.blueScore.toString(),
                                     style: TextStyle(
@@ -193,7 +201,10 @@ class GameWidget extends StatelessWidget {
                             : Text(game.fieldName ?? "",
                                 maxLines: 1,
                                 style: TextStyle(
-                                    fontSize: 16, height: 1, color: timeColor, overflow: TextOverflow.ellipsis))
+                                    fontSize: 16,
+                                    height: 1,
+                                    color: timeColor,
+                                    overflow: TextOverflow.ellipsis))
                       ],
                     ),
                   ),
@@ -202,7 +213,7 @@ class GameWidget extends StatelessWidget {
             ),
             Flexible(
               flex: 25,
-              child: Container(
+              child: SizedBox(
                   height: 50,
                   child: VerticalDivider(
                     thickness: 0.5,

--- a/elapse_app/lib/screens/tournament/pages/schedule/qualification_matches.dart
+++ b/elapse_app/lib/screens/tournament/pages/schedule/qualification_matches.dart
@@ -2,12 +2,10 @@ import 'package:elapse_app/classes/Tournament/game.dart';
 import 'package:elapse_app/screens/tournament/pages/schedule/game_widget.dart';
 import 'package:flutter/material.dart';
 
-import '../../../../classes/Tournament/tournament_mode_functions.dart';
 import '../../../../main.dart';
 
 class MatchesView extends StatelessWidget {
-  const MatchesView(
-      {super.key, required this.games});
+  const MatchesView({super.key, required this.games});
 
   final List<Game> games;
 

--- a/elapse_app/lib/screens/tournament/pages/skills/skills.dart
+++ b/elapse_app/lib/screens/tournament/pages/skills/skills.dart
@@ -35,24 +35,36 @@ class SkillsPage extends StatelessWidget {
     List<TeamPreview> savedTeams = [];
     if (filter.saved) {
       final String savedTeam = prefs.getString("savedTeam") ?? "";
-      TeamPreview savedTeamPreview =
-      TeamPreview(teamID: jsonDecode(savedTeam)["teamID"], teamNumber: jsonDecode(savedTeam)["teamNumber"]);
+      TeamPreview savedTeamPreview = TeamPreview(
+          teamID: jsonDecode(savedTeam)["teamID"],
+          teamNumber: jsonDecode(savedTeam)["teamNumber"]);
       List<String> savedTeamsString = prefs.getStringList("savedTeams") ?? [];
       savedTeams.add(savedTeamPreview);
       savedTeams.addAll(savedTeamsString
-          .map((e) => TeamPreview(teamID: jsonDecode(e)["teamID"], teamNumber: jsonDecode(e)["teamNumber"]))
+          .map((e) => TeamPreview(
+              teamID: jsonDecode(e)["teamID"],
+              teamNumber: jsonDecode(e)["teamNumber"]))
           .toList());
-      filteredTeams = filteredTeams.where((element) => savedTeams.any((element2) => element2.teamID == element.id)).toList();
+      filteredTeams = filteredTeams
+          .where((element) =>
+              savedTeams.any((element2) => element2.teamID == element.id))
+          .toList();
     }
 
     List<TeamPreview> scoutedTeams = [];
     if (filter.scouted) {
-      filteredTeams = filteredTeams.where((e) => scoutedTeams.any((e2) => e2.teamID == e.id)).toList();
+      filteredTeams = filteredTeams
+          .where((e) => scoutedTeams.any((e2) => e2.teamID == e.id))
+          .toList();
     }
 
-    List<TeamPreview> pickListTeams = (prefs.getStringList("picklist") ?? []).map((e) => loadTeamPreview(e)).toList();
+    List<TeamPreview> pickListTeams = (prefs.getStringList("picklist") ?? [])
+        .map((e) => loadTeamPreview(e))
+        .toList();
     if (filter.onPicklist) {
-      filteredTeams = filteredTeams.where((e) => pickListTeams.any((e2) => e2.teamID == e.id)).toList();
+      filteredTeams = filteredTeams
+          .where((e) => pickListTeams.any((e2) => e2.teamID == e.id))
+          .toList();
     }
 
     if (filteredTeams.isEmpty) {
@@ -86,14 +98,18 @@ class SkillsPage extends StatelessWidget {
         if (skills[b.id]!.driverAttempts == skills[a.id]!.driverAttempts) {
           return skills[a.id]!.rank.compareTo(skills[b.id]!.rank);
         }
-        return skills[b.id]!.driverAttempts.compareTo(skills[a.id]!.driverAttempts);
+        return skills[b.id]!
+            .driverAttempts
+            .compareTo(skills[a.id]!.driverAttempts);
       });
     } else if (sort == 4) {
       filteredTeams.sort((a, b) {
         if (skills[b.id]!.autonAttempts == skills[a.id]!.autonAttempts) {
           return skills[a.id]!.rank.compareTo(skills[b.id]!.rank);
         }
-        return skills[b.id]!.autonAttempts.compareTo(skills[a.id]!.autonAttempts);
+        return skills[b.id]!
+            .autonAttempts
+            .compareTo(skills[a.id]!.autonAttempts);
       });
     }
 

--- a/elapse_app/lib/screens/tournament/pages/skills/skills_widget.dart
+++ b/elapse_app/lib/screens/tournament/pages/skills/skills_widget.dart
@@ -5,14 +5,16 @@ import 'package:flutter/material.dart';
 import '../rankings/tournament_stats_page.dart';
 
 class SkillsWidget extends StatelessWidget {
-  const SkillsWidget({Key? key, required this.team, required this.stats}) : super(key: key);
+  const SkillsWidget({super.key, required this.team, required this.stats});
 
   final Team team;
   final TournamentSkills stats;
+  @override
   Widget build(BuildContext context) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: () => tournamentStatsPage(context, team.id, team.teamNumber!, team.teamName!),
+      onTap: () => tournamentStatsPage(
+          context, team.id, team.teamNumber!, team.teamName!),
       child: Container(
           height: 72,
           alignment: Alignment.center,
@@ -40,13 +42,17 @@ class SkillsWidget extends StatelessWidget {
                                         height: 1,
                                         letterSpacing: -1.5,
                                         fontWeight: FontWeight.w400,
-                                        color: Theme.of(context).colorScheme.onSurface)),
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface)),
                                 Text(team.teamName!,
                                     softWrap: false,
                                     style: TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.w300,
-                                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant,
                                       overflow: TextOverflow.fade,
                                     ))
                               ])),

--- a/elapse_app/lib/screens/tournament/tournament.dart
+++ b/elapse_app/lib/screens/tournament/tournament.dart
@@ -50,7 +50,7 @@ class _TournamentScreenState extends State<TournamentScreen> {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const TournamentLoadingScreen();
         } else if (snapshot.hasData) {
-          Tournament tournament = snapshot.data! as Tournament;
+          Tournament tournament = snapshot.data!;
           prefs.setString(
               "recently-opened-tournament", jsonEncode(tournament.toJson()));
           return TournamentLoadedScreen(

--- a/elapse_app/lib/screens/tournament_mode/home.dart
+++ b/elapse_app/lib/screens/tournament_mode/home.dart
@@ -12,7 +12,6 @@ import 'package:elapse_app/screens/widgets/settings_button.dart';
 import 'package:flutter/material.dart';
 
 import '../../classes/Tournament/division.dart';
-import '../../classes/Tournament/tstats.dart';
 
 import 'package:elapse_app/classes/Miscellaneous/remote_config.dart';
 
@@ -85,12 +84,10 @@ class _TMHomePageState extends State<TMHomePage> {
                     child: Column(
                       children: [
                         const Spacer(),
-                        
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           crossAxisAlignment: CrossAxisAlignment.end,
                           children: [
-                            
                             Text(
                               welcomeMessage,
                               style: TextStyle(
@@ -98,59 +95,56 @@ class _TMHomePageState extends State<TMHomePage> {
                             ),
                             showVDAWarn
                                 ? IconButton(
-                                      splashRadius:2,
-                                      icon: const Icon(Icons.sync_problem,
-                                          size: 24,
-                                          color: Color.fromRGBO(0, 0, 0, 1)),
-                                      onPressed: () {
-                                        showDialog(
-                                            context: context,
-                                            builder: (context) {
-                                              return AlertDialog(
-                                                shape: RoundedRectangleBorder(
-                                                    borderRadius:
-                                                        BorderRadius.circular(
-                                                            18)),
-                                                title: Column(
-                                                    crossAxisAlignment:
-                                                        CrossAxisAlignment
-                                                            .start,
-                                                    children: [
-                                                      Text(
-                                                        "Some experiences may be limited",
-                                                        style: TextStyle(
-                                                            fontSize: 20),
-                                                      ),
-                                                      Padding(
-                                                        padding:
-                                                            EdgeInsets.only(
-                                                                top: 5),
-                                                        child: Text(
-                                                          "One of our data sources, vrc-data-analysis, isn't functioning properly right now. Some features may be temporarily unavailable.",
-                                                          style: TextStyle(
-                                                              fontSize: 15),
-                                                        ),
-                                                      ),
-                                                    ]),
-                                                actions: [
-                                                  TextButton(
-                                                    onPressed: () {
-                                                      Navigator.pop(context);
-                                                    },
-                                                    child: Text(
-                                                      "OK",
+                                    splashRadius: 2,
+                                    icon: const Icon(Icons.sync_problem,
+                                        size: 24,
+                                        color: Color.fromRGBO(0, 0, 0, 1)),
+                                    onPressed: () {
+                                      showDialog(
+                                          context: context,
+                                          builder: (context) {
+                                            return AlertDialog(
+                                              shape: RoundedRectangleBorder(
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                          18)),
+                                              title: Column(
+                                                  crossAxisAlignment:
+                                                      CrossAxisAlignment.start,
+                                                  children: [
+                                                    Text(
+                                                      "Some experiences may be limited",
                                                       style: TextStyle(
-                                                          color:
-                                                              Theme.of(context)
-                                                                  .colorScheme
-                                                                  .secondary),
+                                                          fontSize: 20),
                                                     ),
+                                                    Padding(
+                                                      padding: EdgeInsets.only(
+                                                          top: 5),
+                                                      child: Text(
+                                                        "One of our data sources, vrc-data-analysis, isn't functioning properly right now. Some features may be temporarily unavailable.",
+                                                        style: TextStyle(
+                                                            fontSize: 15),
+                                                      ),
+                                                    ),
+                                                  ]),
+                                              actions: [
+                                                TextButton(
+                                                  onPressed: () {
+                                                    Navigator.pop(context);
+                                                  },
+                                                  child: Text(
+                                                    "OK",
+                                                    style: TextStyle(
+                                                        color: Theme.of(context)
+                                                            .colorScheme
+                                                            .secondary),
                                                   ),
-                                                ],
-                                              );
-                                            });
-                                      },
-                                    )
+                                                ),
+                                              ],
+                                            );
+                                          });
+                                    },
+                                  )
                                 : Container(height: 1)
                           ],
                         ),
@@ -592,7 +586,7 @@ class _TMHomePageState extends State<TMHomePage> {
                   onPressed: () {
                     prefs.setBool("isTournamentMode", false);
                     prefs.remove("TMSavedTournament");
-                    myAppKey.currentState!.reloadApp();
+                    myAppKey.currentState?.reloadApp();
                   }),
               Spacer(),
             ],

--- a/elapse_app/lib/screens/tournament_mode/my_teams.dart
+++ b/elapse_app/lib/screens/tournament_mode/my_teams.dart
@@ -52,14 +52,17 @@ class TMMyTeamsState extends State<TMMyTeams> {
   void reload() {
     final String savedTeam = prefs.getString("savedTeam") ?? "";
     final parsed = jsonDecode(savedTeam);
-    savedTeamPreview = TeamPreview(teamID: parsed["teamID"], teamNumber: parsed["teamNumber"]);
+    savedTeamPreview =
+        TeamPreview(teamID: parsed["teamID"], teamNumber: parsed["teamNumber"]);
 
     tournament = TMTournamentDetails(widget.tournamentID);
 
     savedTeamStrings = prefs.getStringList("savedTeams") ?? [];
     savedTeamPreviews.add(savedTeamPreview);
     savedTeamPreviews.addAll(savedTeamStrings
-        .map((e) => TeamPreview(teamID: jsonDecode(e)["teamID"], teamNumber: jsonDecode(e)["teamNumber"]))
+        .map((e) => TeamPreview(
+            teamID: jsonDecode(e)["teamID"],
+            teamNumber: jsonDecode(e)["teamNumber"]))
         .toList());
 
     selectedTeamPreview = savedTeamPreview;
@@ -67,9 +70,11 @@ class TMMyTeamsState extends State<TMMyTeams> {
     savedTeamPreviews = savedTeamPreviews.toSet().toList();
     season = seasons[0];
     team = fetchTeam(savedTeamPreview.teamID);
-    teamStats = getTrueSkillDataForTeam(season.vrcId, savedTeamPreview.teamNumber);
+    teamStats =
+        getTrueSkillDataForTeam(season.vrcId, savedTeamPreview.teamNumber);
     skillsStats = getWorldSkillsForTeam(season.vrcId, savedTeamPreview.teamID);
-    teamTournaments = fetchTeamTournaments(savedTeamPreview.teamID, season.vrcId);
+    teamTournaments =
+        fetchTeamTournaments(savedTeamPreview.teamID, season.vrcId);
     teamAwards = getAwards(savedTeamPreview.teamID, season.vrcId);
   }
 
@@ -118,15 +123,20 @@ class TMMyTeamsState extends State<TMMyTeams> {
                         Season updated = await Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (context) => SeasonFilterPage(selected: season),
+                            builder: (context) =>
+                                SeasonFilterPage(selected: season),
                           ),
                         );
                         setState(() {
                           season = updated;
-                          skillsStats = getWorldSkillsForTeam(season.vrcId, savedTeamPreview.teamID);
-                          teamStats = getTrueSkillDataForTeam(season.vrcId, savedTeamPreview.teamNumber);
-                          teamTournaments = fetchTeamTournaments(savedTeamPreview.teamID, season.vrcId);
-                          teamAwards = getAwards(savedTeamPreview.teamID, season.vrcId);
+                          skillsStats = getWorldSkillsForTeam(
+                              season.vrcId, savedTeamPreview.teamID);
+                          teamStats = getTrueSkillDataForTeam(
+                              season.vrcId, savedTeamPreview.teamNumber);
+                          teamTournaments = fetchTeamTournaments(
+                              savedTeamPreview.teamID, season.vrcId);
+                          teamAwards =
+                              getAwards(savedTeamPreview.teamID, season.vrcId);
                         });
                       },
                       child: Row(children: [
@@ -154,8 +164,10 @@ class TMMyTeamsState extends State<TMMyTeams> {
             sliver: SliverToBoxAdapter(
               child: Container(
                 decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(18), color: Theme.of(context).colorScheme.tertiary),
-                padding: const EdgeInsets.only(left: 18, right: 18, bottom: 18, top: 18),
+                    borderRadius: BorderRadius.circular(18),
+                    color: Theme.of(context).colorScheme.tertiary),
+                padding: const EdgeInsets.only(
+                    left: 18, right: 18, bottom: 18, top: 18),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -194,7 +206,9 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                       style: TextStyle(fontSize: 24),
                                     ),
                                     const Spacer(),
-                                    Container(width: 75, child: const LinearProgressIndicator()),
+                                    SizedBox(
+                                        width: 75,
+                                        child: const LinearProgressIndicator()),
                                   ],
                                 ),
                                 const SizedBox(
@@ -207,7 +221,9 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                       style: TextStyle(fontSize: 24),
                                     ),
                                     const Spacer(),
-                                    Container(width: 75, child: const LinearProgressIndicator()),
+                                    SizedBox(
+                                        width: 75,
+                                        child: const LinearProgressIndicator()),
                                   ],
                                 ),
                               ],
@@ -246,7 +262,9 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                     const Spacer(),
                                     Text(
                                       qualificationString,
-                                      style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.w500),
                                     ),
                                   ],
                                 ),
@@ -262,7 +280,9 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                     const Spacer(),
                                     Text(
                                       "${stats.winPercent == null ? "" : stats.winPercent!.toStringAsFixed(1)}%",
-                                      style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.w500),
                                     ),
                                   ],
                                 ),
@@ -299,7 +319,11 @@ class TMMyTeamsState extends State<TMMyTeams> {
                             organization: "",
                           );
                         } else {
-                          return TeamBio(grade: "", location: Location(), teamName: "", organization: "");
+                          return TeamBio(
+                              grade: "",
+                              location: Location(),
+                              teamName: "",
+                              organization: "");
                         }
                       },
                     )
@@ -318,7 +342,8 @@ class TMMyTeamsState extends State<TMMyTeams> {
                       Tournament tournament = snapshot.data as Tournament;
                       if (!tournament.teams.any(
                         (element) {
-                          return element.teamNumber == selectedTeamPreview.teamNumber;
+                          return element.teamNumber ==
+                              selectedTeamPreview.teamNumber;
                         },
                       )) {
                         return Container();
@@ -339,25 +364,31 @@ class TMMyTeamsState extends State<TMMyTeams> {
                               height: 10,
                             ),
                             RankingOverviewWidget(
-                                teamStats: tournament.divisions[0].teamStats![selectedTeamPreview.teamID]!,
+                                teamStats: tournament.divisions[0]
+                                    .teamStats![selectedTeamPreview.teamID]!,
                                 skills: tournament.tournamentSkills!,
                                 teamID: selectedTeamPreview.teamID),
                             SizedBox(
                               height: 10,
                             ),
                             Column(
-                              children:
-                                  getTeamGames(tournament.divisions[0].games!, selectedTeamPreview.teamNumber).map(
+                              children: getTeamGames(
+                                      tournament.divisions[0].games!,
+                                      selectedTeamPreview.teamNumber)
+                                  .map(
                                 (e) {
                                   return Column(
                                     children: [
                                       GameWidget(
                                         game: e,
-                                        teamName: selectedTeamPreview.teamNumber,
+                                        teamName:
+                                            selectedTeamPreview.teamNumber,
                                         isAllianceColoured: false,
                                       ),
                                       Divider(
-                                        color: Theme.of(context).colorScheme.surfaceDim,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceDim,
                                       )
                                     ],
                                   );
@@ -406,7 +437,8 @@ class TMMyTeamsState extends State<TMMyTeams> {
                           children: [
                             Text(
                               stats.worldSkillsRank.toString(),
-                              style: const TextStyle(fontSize: 64, height: 1, letterSpacing: -2),
+                              style: const TextStyle(
+                                  fontSize: 64, height: 1, letterSpacing: -2),
                             ),
                             const SizedBox(
                               height: 5,
@@ -425,9 +457,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.skillsScore.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Score", style: TextStyle(fontSize: 16))
+                                    const Text("Score",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(
@@ -438,9 +473,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.maxDriver.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Driver", style: TextStyle(fontSize: 16))
+                                    const Text("Driver",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(
@@ -451,9 +489,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.maxAuto.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Auto", style: TextStyle(fontSize: 16))
+                                    const Text("Auto",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 )
                               ],
@@ -511,7 +552,8 @@ class TMMyTeamsState extends State<TMMyTeams> {
                           children: [
                             Text(
                               stats.trueSkillGlobalRank.toString(),
-                              style: const TextStyle(fontSize: 64, height: 1, letterSpacing: -2),
+                              style: const TextStyle(
+                                  fontSize: 64, height: 1, letterSpacing: -2),
                             ),
                             const SizedBox(
                               height: 5,
@@ -530,9 +572,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.trueSkill.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Score", style: TextStyle(fontSize: 16))
+                                    const Text("Score",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(
@@ -543,9 +588,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.trueSkillRegionRank.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("Region Rank", style: TextStyle(fontSize: 16))
+                                    const Text("Region Rank",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(
@@ -563,9 +611,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.opr.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("OPR", style: TextStyle(fontSize: 16))
+                                    const Text("OPR",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(
@@ -576,9 +627,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.dpr.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("DPR", style: TextStyle(fontSize: 16))
+                                    const Text("DPR",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                                 const SizedBox(
@@ -589,9 +643,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                   children: [
                                     Text(
                                       stats.ccwm.toString(),
-                                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                      style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500),
                                     ),
-                                    const Text("CCWM", style: TextStyle(fontSize: 16))
+                                    const Text("CCWM",
+                                        style: TextStyle(fontSize: 16))
                                   ],
                                 ),
                               ],
@@ -616,7 +673,7 @@ class TMMyTeamsState extends State<TMMyTeams> {
             ),
           ),
           const SliverToBoxAdapter(
-            child: const SizedBox(
+            child: SizedBox(
               height: 28,
             ),
           ),
@@ -655,9 +712,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                 children: [
                                   Text(
                                     stats.wins.toString(),
-                                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                    style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w500),
                                   ),
-                                  const Text("Wins", style: TextStyle(fontSize: 16))
+                                  const Text("Wins",
+                                      style: TextStyle(fontSize: 16))
                                 ],
                               ),
                               const SizedBox(width: 18),
@@ -666,9 +726,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                 children: [
                                   Text(
                                     stats.losses.toString(),
-                                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                    style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w500),
                                   ),
-                                  const Text("Losses", style: TextStyle(fontSize: 16))
+                                  const Text("Losses",
+                                      style: TextStyle(fontSize: 16))
                                 ],
                               ),
                               const SizedBox(width: 18),
@@ -677,9 +740,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                 children: [
                                   Text(
                                     stats.ties.toString(),
-                                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                    style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w500),
                                   ),
-                                  const Text("Ties", style: TextStyle(fontSize: 16))
+                                  const Text("Ties",
+                                      style: TextStyle(fontSize: 16))
                                 ],
                               ),
                               const SizedBox(width: 18),
@@ -688,9 +754,12 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                 children: [
                                   Text(
                                     stats.matches.toString(),
-                                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                    style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w500),
                                   ),
-                                  const Text("Matches", style: TextStyle(fontSize: 16))
+                                  const Text("Matches",
+                                      style: TextStyle(fontSize: 16))
                                 ],
                               ),
                               const SizedBox(width: 18),
@@ -742,7 +811,7 @@ class TMMyTeamsState extends State<TMMyTeams> {
                       }
 
                       List<Award> awards = snapshot.data as List<Award>;
-                      if (awards.isNotEmpty)
+                      if (awards.isNotEmpty) {
                         return Container(
                           padding: const EdgeInsets.all(18),
                           decoration: BoxDecoration(
@@ -756,11 +825,15 @@ class TMMyTeamsState extends State<TMMyTeams> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
-                                  const Text("Awards", style: TextStyle(fontSize: 24)),
+                                  const Text("Awards",
+                                      style: TextStyle(fontSize: 24)),
                                   Text(awards.length.toString(),
-                                      style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500))
+                                      style: const TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.w500))
                                 ],
                               ),
                               const SizedBox(height: 18),
@@ -772,28 +845,35 @@ class TMMyTeamsState extends State<TMMyTeams> {
                                         alignment: Alignment.centerLeft,
                                         height: 60,
                                         child: Column(
-                                          crossAxisAlignment: CrossAxisAlignment.start,
-                                          mainAxisAlignment: MainAxisAlignment.center,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
                                           children: [
                                             Text(
                                               e.name,
                                               overflow: TextOverflow.ellipsis,
                                               textAlign: TextAlign.start,
                                               maxLines: 1,
-                                              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                                              style: const TextStyle(
+                                                  fontSize: 16,
+                                                  fontWeight: FontWeight.w500),
                                             ),
                                             Text(
                                               maxLines: 1,
                                               overflow: TextOverflow.ellipsis,
                                               textAlign: TextAlign.start,
                                               e.tournamentName ?? "",
-                                              style: const TextStyle(fontSize: 16),
+                                              style:
+                                                  const TextStyle(fontSize: 16),
                                             )
                                           ],
                                         ),
                                       ),
                                       Divider(
-                                        color: Theme.of(context).colorScheme.surfaceDim,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceDim,
                                       )
                                     ],
                                   );
@@ -802,8 +882,9 @@ class TMMyTeamsState extends State<TMMyTeams> {
                             ],
                           ),
                         );
-                      else
+                      } else {
                         return Container();
+                      }
                   }
                 },
               ),
@@ -831,11 +912,13 @@ class TMMyTeamsState extends State<TMMyTeams> {
                     future: teamTournaments,
                     builder: (context, snapshot) {
                       if (snapshot.hasData) {
-                        List<TournamentPreview> tournaments = snapshot.data as List<TournamentPreview>;
+                        List<TournamentPreview> tournaments =
+                            snapshot.data as List<TournamentPreview>;
                         return Column(
                           children: tournaments
                               .map(
-                                (e) => TournamentPreviewWidget(tournamentPreview: e),
+                                (e) => TournamentPreviewWidget(
+                                    tournamentPreview: e),
                               )
                               .toList(),
                         );
@@ -860,7 +943,8 @@ class TMMyTeamsState extends State<TMMyTeams> {
                   child: TextButton(
                     child: Text(
                       "Remove Team",
-                      style: TextStyle(fontSize: 18, color: colorPallete.redAllianceText),
+                      style: TextStyle(
+                          fontSize: 18, color: colorPallete.redAllianceText),
                     ),
                     onPressed: () {
                       setState(

--- a/elapse_app/lib/screens/tournament_mode/picklist/picklist.dart
+++ b/elapse_app/lib/screens/tournament_mode/picklist/picklist.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:ui';
 
 import 'package:carousel_slider/carousel_controller.dart';
-import 'package:elapse_app/classes/Tournament/tstats.dart';
 import 'package:elapse_app/screens/tournament_mode/picklist/picklist_widget.dart';
 import 'package:elapse_app/screens/widgets/big_error_message.dart';
 import 'package:flutter/cupertino.dart';
@@ -29,7 +28,9 @@ class _PicklistPageState extends State<PicklistPage> {
 
   void refreshTeams() {
     setState(() {
-      teams = (prefs.getStringList("picklist") ?? []).map((e) => loadTeamPreview(e)).toList();
+      teams = (prefs.getStringList("picklist") ?? [])
+          .map((e) => loadTeamPreview(e))
+          .toList();
       carouselControllers = [];
       for (var _ in teams) {
         carouselControllers.add(CarouselSliderController());
@@ -67,20 +68,27 @@ class _PicklistPageState extends State<PicklistPage> {
                           .map<int, Widget>((i, e) {
                             return MapEntry(
                                 i,
-                                Column(key: UniqueKey(), mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-                                  PicklistWidget(
-                                      index: i,
-                                      team: e,
-                                      tournament: tournament,
-                                      carouselControllers: carouselControllers,
-                                      refresh: refreshTeams),
-                                  i != teams.length - 1
-                                      ? Divider(
-                                          color: Theme.of(context).colorScheme.surfaceDim,
-                                          height: 3,
-                                        )
-                                      : const SizedBox.shrink(),
-                                ]));
+                                Column(
+                                    key: UniqueKey(),
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      PicklistWidget(
+                                          index: i,
+                                          team: e,
+                                          tournament: tournament,
+                                          carouselControllers:
+                                              carouselControllers,
+                                          refresh: refreshTeams),
+                                      i != teams.length - 1
+                                          ? Divider(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .surfaceDim,
+                                              height: 3,
+                                            )
+                                          : const SizedBox.shrink(),
+                                    ]));
                           })
                           .values
                           .toList(),
@@ -92,14 +100,19 @@ class _PicklistPageState extends State<PicklistPage> {
                         });
                       },
                       onReorderEnd: (int index) {
-                        prefs.setStringList("picklist", teams.map((e) => jsonEncode(e.toJson())).toList());
+                        prefs.setStringList("picklist",
+                            teams.map((e) => jsonEncode(e.toJson())).toList());
                       },
-                      proxyDecorator: (child, index, animation) => AnimatedBuilder(
+                      proxyDecorator: (child, index, animation) =>
+                          AnimatedBuilder(
                             animation: animation,
                             builder: (context, child) => Material(
-                              elevation: lerpDouble(0, 6, Curves.easeInOut.transform(animation.value))!,
-                              borderRadius: const BorderRadius.all(Radius.circular(18)),
-                              shadowColor: Theme.of(context).colorScheme.tertiary,
+                              elevation: lerpDouble(0, 6,
+                                  Curves.easeInOut.transform(animation.value))!,
+                              borderRadius:
+                                  const BorderRadius.all(Radius.circular(18)),
+                              shadowColor:
+                                  Theme.of(context).colorScheme.tertiary,
                               child: child,
                             ),
                             child: child,
@@ -107,7 +120,9 @@ class _PicklistPageState extends State<PicklistPage> {
                 )
               : const SliverToBoxAdapter(
                   child: BigErrorMessage(
-                      icon: Icons.list_alt_outlined, message: "Picklist is only available during tournament mode")),
+                      icon: Icons.list_alt_outlined,
+                      message:
+                          "Picklist is only available during tournament mode")),
         ]));
   }
 }

--- a/elapse_app/lib/screens/tournament_mode/picklist/picklist_widget.dart
+++ b/elapse_app/lib/screens/tournament_mode/picklist/picklist_widget.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:collection/collection.dart';
@@ -40,9 +39,12 @@ class PicklistWidget extends StatelessWidget {
             key: Key("$index"),
             direction: DismissDirection.endToStart,
             onDismissed: (direction) {
-              final picklist = (prefs.getStringList("picklist") ?? []).map((e) => loadTeamPreview(e)).toList();
+              final picklist = (prefs.getStringList("picklist") ?? [])
+                  .map((e) => loadTeamPreview(e))
+                  .toList();
               picklist.remove(team);
-              prefs.setStringList("picklist", picklist.map((e) => jsonEncode(e.toJson())).toList());
+              prefs.setStringList("picklist",
+                  picklist.map((e) => jsonEncode(e.toJson())).toList());
               print(picklist);
               refresh();
             },
@@ -50,7 +52,8 @@ class PicklistWidget extends StatelessWidget {
               padding: const EdgeInsets.only(right: 20),
               alignment: Alignment.centerRight,
               color: Theme.of(context).colorScheme.error,
-              child: Icon(Icons.delete, color: Theme.of(context).colorScheme.surface),
+              child: Icon(Icons.delete,
+                  color: Theme.of(context).colorScheme.surface),
             ),
             child: Container(
                 height: 72,
@@ -64,21 +67,26 @@ class PicklistWidget extends StatelessWidget {
                   Flexible(
                     flex: 15,
                     fit: FlexFit.tight,
-                    child: ReorderableDragStartListener(index: index, child: const Icon(Icons.drag_indicator)),
+                    child: ReorderableDragStartListener(
+                        index: index, child: const Icon(Icons.drag_indicator)),
                   ),
                   Flexible(
                     flex: 20,
                     fit: FlexFit.tight,
                     child: Text("${index + 1}.",
                         style: TextStyle(
-                            color: Theme.of(context).colorScheme.onSurface, fontSize: 24, fontWeight: FontWeight.w600)),
+                            color: Theme.of(context).colorScheme.onSurface,
+                            fontSize: 24,
+                            fontWeight: FontWeight.w600)),
                   ),
                   Flexible(
                     flex: 100,
                     fit: FlexFit.tight,
                     child: Text(team.teamNumber,
                         style: TextStyle(
-                            color: Theme.of(context).colorScheme.onSurface, fontSize: 36, fontWeight: FontWeight.w400)),
+                            color: Theme.of(context).colorScheme.onSurface,
+                            fontSize: 36,
+                            fontWeight: FontWeight.w400)),
                   ),
                   Flexible(
                     flex: 90,
@@ -90,7 +98,8 @@ class PicklistWidget extends StatelessWidget {
                             case ConnectionState.none:
                             case ConnectionState.waiting:
                             case ConnectionState.active:
-                              return const Center(child: CircularProgressIndicator());
+                              return const Center(
+                                  child: CircularProgressIndicator());
                             case ConnectionState.done:
                               if (snapshot.hasError) {
                                 print(snapshot.error);
@@ -99,22 +108,31 @@ class PicklistWidget extends StatelessWidget {
 
                               TeamStats stats = (snapshot.data as Tournament)
                                   .divisions
-                                  .firstWhereOrNull((e) => e.teamStats?.containsKey(team.teamID) ?? false)!
+                                  .firstWhereOrNull((e) =>
+                                      e.teamStats?.containsKey(team.teamID) ??
+                                      false)!
                                   .teamStats![team.teamID]!;
 
                               List<Widget> pages = [
                                 Padding(
-                                  padding: const EdgeInsets.symmetric(horizontal: 5),
+                                  padding:
+                                      const EdgeInsets.symmetric(horizontal: 5),
                                   child: Row(children: [
                                     Flexible(
                                         flex: 50,
                                         fit: FlexFit.tight,
                                         child: Column(
-                                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                                            crossAxisAlignment: CrossAxisAlignment.start,
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.spaceEvenly,
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
                                             children: [
-                                              Text("Rank ${stats.rank}", style: const TextStyle(fontSize: 16)),
-                                              Text("${stats.wp} WP", style: const TextStyle(fontSize: 16)),
+                                              Text("Rank ${stats.rank}",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
+                                              Text("${stats.wp} WP",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
                                             ])),
                                     Flexible(
                                       flex: 5,
@@ -122,35 +140,51 @@ class PicklistWidget extends StatelessWidget {
                                       child: SizedBox(
                                         height: 50,
                                         child: VerticalDivider(
-                                            thickness: 0.5, color: Theme.of(context).colorScheme.surfaceDim),
+                                            thickness: 0.5,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .surfaceDim),
                                       ),
                                     ),
                                     Flexible(
                                         flex: 50,
                                         fit: FlexFit.tight,
                                         child: Column(
-                                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                                            crossAxisAlignment: CrossAxisAlignment.end,
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.spaceEvenly,
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.end,
                                             children: [
-                                              Text("${stats.ap} AP", style: const TextStyle(fontSize: 16)),
-                                              Text("${stats.sp} SP", style: const TextStyle(fontSize: 16)),
+                                              Text("${stats.ap} AP",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
+                                              Text("${stats.sp} SP",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
                                             ])),
                                   ]),
                                 ),
                                 Padding(
-                                  padding: const EdgeInsets.symmetric(horizontal: 5),
+                                  padding:
+                                      const EdgeInsets.symmetric(horizontal: 5),
                                   child: Row(children: [
                                     Flexible(
                                         flex: 50,
                                         fit: FlexFit.tight,
                                         child: Column(
-                                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                                            crossAxisAlignment: CrossAxisAlignment.start,
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.spaceEvenly,
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
                                             children: [
-                                              Text("${stats.wins}-${stats.losses}-${stats.ties}",
-                                                  style: const TextStyle(fontSize: 16)),
-                                              Text("${(stats.wins / stats.totalMatches * 100).toStringAsFixed(1)}%",
-                                                  style: const TextStyle(fontSize: 16)),
+                                              Text(
+                                                  "${stats.wins}-${stats.losses}-${stats.ties}",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
+                                              Text(
+                                                  "${(stats.wins / stats.totalMatches * 100).toStringAsFixed(1)}%",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
                                             ])),
                                     Flexible(
                                       flex: 5,
@@ -158,36 +192,52 @@ class PicklistWidget extends StatelessWidget {
                                       child: SizedBox(
                                         height: 50,
                                         child: VerticalDivider(
-                                            thickness: 0.5, color: Theme.of(context).colorScheme.surfaceDim),
+                                            thickness: 0.5,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .surfaceDim),
                                       ),
                                     ),
                                     Flexible(
                                         flex: 50,
                                         fit: FlexFit.tight,
                                         child: Column(
-                                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                                            crossAxisAlignment: CrossAxisAlignment.end,
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.spaceEvenly,
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.end,
                                             children: [
-                                              Text("${stats.awp} AWP", style: const TextStyle(fontSize: 16)),
-                                              Text("${(stats.awpRate * 100).toStringAsFixed(1)}%",
-                                                  style: const TextStyle(fontSize: 16)),
+                                              Text("${stats.awp} AWP",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
+                                              Text(
+                                                  "${(stats.awpRate * 100).toStringAsFixed(1)}%",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
                                             ])),
                                   ]),
                                 ),
                                 Padding(
-                                  padding: const EdgeInsets.symmetric(horizontal: 5),
+                                  padding:
+                                      const EdgeInsets.symmetric(horizontal: 5),
                                   child: Row(children: [
                                     Flexible(
                                         flex: 50,
                                         fit: FlexFit.tight,
                                         child: Column(
-                                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                                            crossAxisAlignment: CrossAxisAlignment.start,
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.spaceEvenly,
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
                                             children: [
-                                              Text("${stats.opr.toStringAsFixed(1)} OPR",
-                                                  style: const TextStyle(fontSize: 16)),
-                                              Text("${stats.dpr.toStringAsFixed(1)} DPR",
-                                                  style: const TextStyle(fontSize: 16)),
+                                              Text(
+                                                  "${stats.opr.toStringAsFixed(1)} OPR",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
+                                              Text(
+                                                  "${stats.dpr.toStringAsFixed(1)} DPR",
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
                                             ])),
                                     Flexible(
                                       flex: 5,
@@ -195,18 +245,28 @@ class PicklistWidget extends StatelessWidget {
                                       child: SizedBox(
                                         height: 50,
                                         child: VerticalDivider(
-                                            thickness: 0.5, color: Theme.of(context).colorScheme.surfaceDim),
+                                            thickness: 0.5,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .surfaceDim),
                                       ),
                                     ),
                                     Flexible(
                                         flex: 40,
                                         fit: FlexFit.tight,
                                         child: Column(
-                                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                                            crossAxisAlignment: CrossAxisAlignment.end,
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.spaceEvenly,
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.end,
                                             children: [
-                                              Text(stats.ccwm.toStringAsFixed(1), style: const TextStyle(fontSize: 16)),
-                                              const Text("CCWM", style: TextStyle(fontSize: 16)),
+                                              Text(
+                                                  stats.ccwm.toStringAsFixed(1),
+                                                  style: const TextStyle(
+                                                      fontSize: 16)),
+                                              const Text("CCWM",
+                                                  style:
+                                                      TextStyle(fontSize: 16)),
                                             ])),
                                   ]),
                                 ),
@@ -221,7 +281,9 @@ class PicklistWidget extends StatelessWidget {
                                   onPageChanged: (index, reason) {
                                     for (final c in carouselControllers) {
                                       c.animateToPage(index,
-                                          duration: const Duration(milliseconds: 100), curve: Curves.fastOutSlowIn);
+                                          duration:
+                                              const Duration(milliseconds: 100),
+                                          curve: Curves.fastOutSlowIn);
                                     }
                                   },
                                 ),

--- a/elapse_app/lib/screens/tournament_mode/tournament.dart
+++ b/elapse_app/lib/screens/tournament_mode/tournament.dart
@@ -46,7 +46,6 @@ class _TMTournamentScreenState extends State<TMTournamentScreen> {
                   expandedHeight: 125,
                   centerTitle: false,
                   backgroundColor: Theme.of(context).colorScheme.primary,
-                  
                 ),
                 SliverPersistentHeader(
                     pinned: true,
@@ -129,7 +128,7 @@ class _TMTournamentScreenState extends State<TMTournamentScreen> {
     return Stack(
       alignment: Alignment.center,
       children: [
-        Container(
+        SizedBox(
           width: 50,
           height: 50,
         ),

--- a/elapse_app/lib/screens/tournament_mode/widgets/next_game.dart
+++ b/elapse_app/lib/screens/tournament_mode/widgets/next_game.dart
@@ -32,9 +32,11 @@ class NextGame extends StatelessWidget {
   Widget build(BuildContext context) {
     String timeString;
     if (game.startedTime != null) {
-      timeString = twelveHour(DateFormat.Hm().format(game.startedTime!.toLocal()));
+      timeString =
+          twelveHour(DateFormat.Hm().format(game.startedTime!.toLocal()));
     } else if (game.scheduledTime != null && game.startedTime == null) {
-      timeString = twelveHour(DateFormat.Hm().format(game.scheduledTime!.toLocal()));
+      timeString =
+          twelveHour(DateFormat.Hm().format(game.scheduledTime!.toLocal()));
     } else {
       timeString = "No Time";
     }
@@ -48,11 +50,13 @@ class NextGame extends StatelessWidget {
     }
 
     bool isBlue(String teamNumber) {
-      return game.blueAlliancePreview!.any((element) => element.teamNumber == teamNumber);
+      return game.blueAlliancePreview!
+          .any((element) => element.teamNumber == teamNumber);
     }
 
     bool isRed(String teamNumber) {
-      return game.redAlliancePreview!.any((element) => element.teamNumber == teamNumber);
+      return game.redAlliancePreview!
+          .any((element) => element.teamNumber == teamNumber);
     }
 
     if (targetTeam != null) {
@@ -63,7 +67,8 @@ class NextGame extends StatelessWidget {
       }
     }
 
-    Game? currGame = games.lastWhereOrNull((e) => (e.redScore != 0 && e.blueScore != 0) || e.startedTime != null);
+    Game? currGame = games.lastWhereOrNull(
+        (e) => (e.redScore != 0 && e.blueScore != 0) || e.startedTime != null);
     int gamesLeft = games.indexOf(game);
     if (currGame != null) {
       gamesLeft -= games.indexOf(currGame);
@@ -113,7 +118,8 @@ class NextGame extends StatelessWidget {
       },
       child: Container(
         padding: EdgeInsets.all(18),
-        decoration: BoxDecoration(color: backgroundColor, borderRadius: BorderRadius.circular(18)),
+        decoration: BoxDecoration(
+            color: backgroundColor, borderRadius: BorderRadius.circular(18)),
         child: Column(
           children: [
             Row(
@@ -145,7 +151,9 @@ class NextGame extends StatelessWidget {
                       e.teamNumber,
                       style: TextStyle(
                           fontSize: 24,
-                          fontWeight: e.teamNumber == targetTeam?.teamNumber ? FontWeight.w500 : FontWeight.normal),
+                          fontWeight: e.teamNumber == targetTeam?.teamNumber
+                              ? FontWeight.w500
+                              : FontWeight.normal),
                     );
                   }).toList(),
                 ),
@@ -156,7 +164,9 @@ class NextGame extends StatelessWidget {
                       e.teamNumber,
                       style: TextStyle(
                           fontSize: 24,
-                          fontWeight: e.teamNumber == targetTeam?.teamNumber ? FontWeight.w600 : FontWeight.normal),
+                          fontWeight: e.teamNumber == targetTeam?.teamNumber
+                              ? FontWeight.w600
+                              : FontWeight.normal),
                     );
                   }).toList(),
                 )
@@ -164,7 +174,10 @@ class NextGame extends StatelessWidget {
             ),
             SizedBox(height: 10),
             Divider(
-              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2),
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.2),
               height: 3,
             ),
             SizedBox(height: 10, width: 50),
@@ -173,38 +186,39 @@ class NextGame extends StatelessWidget {
               children: [
                 Row(
                   children: [
-                    Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                      Text(
-                        timeString,
-                        style: TextStyle(
-                          fontSize: 24,
-                        ),
-                      ),
-                      Text(
-                        "Time",
-                        style: TextStyle(fontSize: 16),
-                      ),
-                    ]),
+                    Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            timeString,
+                            style: TextStyle(
+                              fontSize: 24,
+                            ),
+                          ),
+                          Text(
+                            "Time",
+                            style: TextStyle(fontSize: 16),
+                          ),
+                        ]),
                     Spacer(),
                     Align(
-                    alignment: Alignment.centerRight,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.end, 
-                      children: [
-                        Text(
-                          "$gamesLeft",
-                          style: const TextStyle(
-                            fontSize: 24,
-                          ),
-                          textAlign: TextAlign.right,
-                        ),
-                        const Text(
-                          "Matches Remaining",
-                          style: TextStyle(fontSize: 16),
-                          textAlign: TextAlign.right,
-                        ),  
-                      ])
-                    ),
+                        alignment: Alignment.centerRight,
+                        child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              Text(
+                                "$gamesLeft",
+                                style: const TextStyle(
+                                  fontSize: 24,
+                                ),
+                                textAlign: TextAlign.right,
+                              ),
+                              const Text(
+                                "Matches Remaining",
+                                style: TextStyle(fontSize: 16),
+                                textAlign: TextAlign.right,
+                              ),
+                            ])),
                   ],
                 ),
                 SizedBox(

--- a/elapse_app/lib/screens/widgets/big_error_message.dart
+++ b/elapse_app/lib/screens/widgets/big_error_message.dart
@@ -33,7 +33,8 @@ class BigErrorMessage extends StatelessWidget {
         Text(
           message,
           style: TextStyle(
-            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.75),
+            color:
+                Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.75),
           ),
         ),
       ],

--- a/elapse_app/lib/screens/widgets/custom_tab_bar.dart
+++ b/elapse_app/lib/screens/widgets/custom_tab_bar.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
 
 class CustomTabBar extends StatefulWidget {
-  const CustomTabBar({super.key, required this.tabs, required this.onPressed, this.disabledTabs, this.initIndex = 0});
+  const CustomTabBar(
+      {super.key,
+      required this.tabs,
+      required this.onPressed,
+      this.disabledTabs,
+      this.initIndex = 0});
   final List<String> tabs;
   final List<bool>? disabledTabs;
   final void Function(int value) onPressed;
@@ -57,7 +62,8 @@ class _CustomTabBarState extends State<CustomTabBar> {
                     bool isSelected = selectedItem == widget.tabs.indexOf(e);
                     return IntrinsicWidth(
                       child: TextButton(
-                        onPressed: widget.disabledTabs == null || !widget.disabledTabs![widget.tabs.indexOf(e)]
+                        onPressed: widget.disabledTabs == null ||
+                                !widget.disabledTabs![widget.tabs.indexOf(e)]
                             ? () {
                                 setState(() {
                                   selectedItem = widget.tabs.indexOf(e);
@@ -73,9 +79,15 @@ class _CustomTabBarState extends State<CustomTabBar> {
                               style: TextStyle(
                                   color: isSelected
                                       ? Theme.of(context).colorScheme.secondary
-                                      : widget.disabledTabs == null || !widget.disabledTabs![widget.tabs.indexOf(e)]
-                                          ? Theme.of(context).colorScheme.onSurface
-                                          : Theme.of(context).colorScheme.onSurfaceVariant),
+                                      : widget.disabledTabs == null ||
+                                              !widget.disabledTabs![
+                                                  widget.tabs.indexOf(e)]
+                                          ? Theme.of(context)
+                                              .colorScheme
+                                              .onSurface
+                                          : Theme.of(context)
+                                              .colorScheme
+                                              .onSurfaceVariant),
                             ),
                             Spacer(),
                             AnimatedContainer(
@@ -83,7 +95,9 @@ class _CustomTabBarState extends State<CustomTabBar> {
                               curve: Curves.easeInOut,
                               height: 3,
                               decoration: BoxDecoration(
-                                color: isSelected ? Theme.of(context).colorScheme.secondary : Colors.transparent,
+                                color: isSelected
+                                    ? Theme.of(context).colorScheme.secondary
+                                    : Colors.transparent,
                                 borderRadius: const BorderRadius.only(
                                   topLeft: Radius.circular(3),
                                   topRight: Radius.circular(3),
@@ -124,12 +138,15 @@ class SliverHeaderDelegate extends SliverPersistentHeaderDelegate {
   double get maxExtent => maxHeight;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
     return SizedBox.expand(child: child);
   }
 
   @override
   bool shouldRebuild(SliverHeaderDelegate oldDelegate) {
-    return oldDelegate.minHeight != minHeight || oldDelegate.maxHeight != maxHeight || oldDelegate.child != child;
+    return oldDelegate.minHeight != minHeight ||
+        oldDelegate.maxHeight != maxHeight ||
+        oldDelegate.child != child;
   }
 }

--- a/elapse_app/lib/screens/widgets/long_button.dart
+++ b/elapse_app/lib/screens/widgets/long_button.dart
@@ -40,7 +40,9 @@ class LongButton extends StatelessWidget {
                 : null,
             border: Border.all(
               width: 2,
-              color: isGray ? Theme.of(context).colorScheme.surfaceDim : Theme.of(context).colorScheme.primary,
+              color: isGray
+                  ? Theme.of(context).colorScheme.surfaceDim
+                  : Theme.of(context).colorScheme.primary,
             ),
           ),
         ),
@@ -53,14 +55,16 @@ class LongButton extends StatelessWidget {
           child: InkWell(
             onTap: onPressed,
             borderRadius: BorderRadius.circular(30),
-            splashColor: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
+            splashColor:
+                Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             child: Container(
               height: 60,
               padding: const EdgeInsets.symmetric(horizontal: 18),
               child: Row(
                 children: [
                   centerAlign ? Spacer() : Container(),
-                  if (icon != null) Icon(icon, color: Theme.of(context).colorScheme.secondary),
+                  if (icon != null)
+                    Icon(icon, color: Theme.of(context).colorScheme.secondary),
                   if (icon != null) const SizedBox(width: 18),
                   Text(
                     text,
@@ -73,7 +77,9 @@ class LongButton extends StatelessWidget {
                   if (useForwardArrow)
                     Icon(
                       trailingIcon,
-                      color: isGray ? Theme.of(context).colorScheme.onSurface : Theme.of(context).colorScheme.secondary,
+                      color: isGray
+                          ? Theme.of(context).colorScheme.onSurface
+                          : Theme.of(context).colorScheme.secondary,
                     )
                 ],
               ),

--- a/elapse_app/lib/screens/widgets/settings_button.dart
+++ b/elapse_app/lib/screens/widgets/settings_button.dart
@@ -1,4 +1,3 @@
-import 'package:elapse_app/main.dart';
 import 'package:elapse_app/screens/settings/settings.dart';
 import 'package:flutter/material.dart';
 
@@ -20,11 +19,13 @@ class SettingsButton extends StatelessWidget {
       iconSize: 30,
       color: Theme.of(context).colorScheme.onSurface,
       onPressed: () {
-        Navigator.of(context, rootNavigator: true).push(
-          MaterialPageRoute(
-            builder: (context) => SettingsScreen(),
-          ),
-        ).then((_) => (callback ?? (() {}))());
+        Navigator.of(context, rootNavigator: true)
+            .push(
+              MaterialPageRoute(
+                builder: (context) => SettingsScreen(),
+              ),
+            )
+            .then((_) => (callback ?? (() {}))());
       },
     );
   }

--- a/elapse_app/lib/screens/widgets/team_widget.dart
+++ b/elapse_app/lib/screens/widgets/team_widget.dart
@@ -1,4 +1,3 @@
-import 'package:elapse_app/classes/Miscellaneous/location.dart';
 import 'package:elapse_app/screens/team_screen/team_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:elapse_app/main.dart';
@@ -52,7 +51,7 @@ class TeamWidget extends StatelessWidget {
           ),
         );
       },
-      child: Container(
+      child: SizedBox(
         height: 72,
         child: Flex(
           direction: Axis.horizontal,
@@ -85,8 +84,7 @@ class TeamWidget extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 16,
                       )),
-                  Text(
-                      subInfo ?? "",
+                  Text(subInfo ?? "",
                       textAlign: TextAlign.end,
                       style: TextStyle(
                         fontSize: 16,

--- a/elapse_app/lib/screens/widgets/tournament_preview_widget.dart
+++ b/elapse_app/lib/screens/widgets/tournament_preview_widget.dart
@@ -57,7 +57,7 @@ class TournamentPreviewWidget extends StatelessWidget {
               ),
             );
           },
-          child: Container(
+          child: SizedBox(
             height: 60,
             child: Flex(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,


### PR DESCRIPTION
# Improve discovery, tournament, and team interfaces

Update competition browsing and team screens to use the revised shared data-loading foundation.

### What changed
- Refactor exploration, search, filters, world rankings, and skills views.
- Update tournament overview, search, rankings, match schedule, and skills screens.
- Refine tournament-mode views, team lists, picklists, and next-match widgets.
- Update team details, existing scouting views, photo controls, and shared screen widgets.

### How this improves the app
The related browsing screens use more consistent loading and presentation patterns. These changes complement the caching foundation when navigating between team and competition information.

### Stack and review scope
Merge order: #76 → #77 → #78 → #79 → #80

- Part 3 of 5. All parts must be merged in order to reproduce the local application.
- Intended incremental scope: 48 files changed, 2589 insertions(+), 1442 deletions(-).
- [Review only this part's changes](https://github.com/UtkarshTewari24/elapse/compare/codex/review-2-account-groups...codex/review-3-discovery-tournaments).
- This PR currently targets upstream `main`. Its Files changed tab is cumulative until a maintainer publishes `codex/review-2-account-groups` in `elapse-app/elapse` and retargets this PR to that branch, or the preceding parts land in `main`.
- Kept as a draft until the base dependency is resolved. Do not merge this part ahead of its predecessors.
- Replaces the overlapping work previously proposed in #74 and #75.

### Validation
- Diff whitespace checks pass and package-local imports resolve at this stage.
- The final stack includes the current local application files, including the previously uncommitted regression tests and verification report.
- Flutter tests and analysis were not rerun: the installed Flutter symlink does not resolve to an executable. Intermediate stages still need compilation and test validation.
- The included verification report describes an older source revision; its results are historical and have not been rerun for this stack.
