### PR TITLE
[5/5] Add guided scouting and saved sheet review

### DIFF
--- a/elapse_app/SCOUTING.md
+++ b/elapse_app/SCOUTING.md
@@ -1,0 +1,22 @@
+# Scouting
+
+## Create a sheet
+
+1. Open **Scout → Start scouting**, or choose **Use template** from the template library.
+2. Enter a team number (the placeholder example is **1523W**) and choose the result.
+3. Select the event. If needed, sign in and create a group for yourself or join your teammates using their invite code. A group is the shared storage location, not a robot/team being scouted.
+4. Tap **Create Scout Sheet**, enter observations, and tap **Save sheet**. The creation flow returns directly to Scout.
+
+Each sheet belongs to one team and one event. Templates define the questions; they are not filled-in sheets. Existing sheets retain their original template.
+
+## Review and compare
+
+Open **Scout → My scout sheets**. Choose **List** or **Table**; the view preference is remembered on this device. The table includes the team, event, template, update date, and answer columns. Scroll horizontally for more columns, and tap a row to open that exact sheet. Long text can be read in the sheet or its tooltip. Blank values show a dash; `false` and `0` remain **No** and **0**.
+
+Sheets load in pages of 25, newest first. **Load more** retrieves the next page. Filtering and team sorting apply to the pages currently loaded. The view contains the selected group's sheets, not only local bookmarks. If event metadata cannot be resolved, its event ID is shown instead.
+
+## Verification
+
+The group, navigation, table, and header regression suite contains 15 passing tests. A full Flutter run on 2026-09-07 passed 41 tests and failed the previously reported legacy-photo deletion regression. That failure and the previously reported Firebase security-rule findings are separate from these usability changes; this is not a production-security sign-off.
+
+The final iOS simulator build succeeded. During manual checking, the existing 10K sheet was saved with a clearly marked test note, and an existing 1523A sheet was reopened without overwriting its answers. Final on-simulator table/restart verification was delayed by simulator boot/install hangs; automated table tests are not a substitute for that remaining check.

--- a/elapse_app/TEST_REPORT.md
+++ b/elapse_app/TEST_REPORT.md
@@ -1,0 +1,39 @@
+# Verification report — 2026-09-06
+
+Scope: branch `codex/vex-api-stability`, application source at `802aa06`, with new regression tests. Production Firebase data and rules were not changed.
+
+## Results
+
+- Full Flutter suite including live VEX API: **26 passed, 1 failed**.
+- Firestore/Storage emulator suite: **8 passed, 2 failed**. Reproduced both in the workspace and an isolated temporary dependency install.
+- Static analysis: **231 informational findings, no errors or warnings**; the default analysis command exits nonzero for these findings.
+- iOS debug simulator build: **passed**, followed by installation and launch on iPhone 17 Pro / iOS 26.5. Application `lib` contents in the temporary build copy matched the workspace.
+- Simulator UI smoke test: **passed** for startup, live upcoming-event display, opening the template manager, creating a one-field custom template, saving, fully restarting the app, and reopening the persisted template list. `E2E Test Template` remains in simulator-local storage; the built-in default was not changed.
+- `git diff --check`: passed.
+
+The live API test covers team search and details, event search, tournament teams/divisions/matches/skills/awards, team awards, and world skills. The emulator lifecycle test covers profile creation, atomic group creation and membership updates, a second member joining, custom sheet persistence and teammate reload, image upload/deletion, admin handoff, access revocation, and final cleanup. It exercises Firebase SDK calls and rules, not the Flutter UI or the application's Database methods. Auth identities are emulator test contexts, not real sign-in sessions.
+
+## Confirmed failures
+
+1. **Deleted legacy photos return after reload.** `ScoutSheetData.fromFirestore` falls back to `properties.Specs.photos` whenever the root photo list is empty, including a migrated document whose photos were explicitly cleared. The new regression expects an empty list but receives `['old-photo']`.
+2. **Joinable groups can be enumerated without a join code.** An authenticated outsider can query `teamGroups` with only `allowJoin == true`, retrieving group documents including their join codes and membership data. The negative-access regression unexpectedly succeeds.
+3. **An admin can erase unrelated user memberships.** If the admin controls the first group in a user's `groupId` list, the rule allows arbitrary replacement of that whole list. The regression clears both the administered group and an unrelated group, and the write unexpectedly succeeds.
+
+These findings apply to the checked-in rules; deployed production rules were not inspected. The failing tests are deliberately active. No application fixes or production deployments are included in this testing change.
+
+## Reproduce
+
+From `elapse_app` with Flutter, Node, Firebase CLI, and Java 21 available:
+
+```sh
+flutter test --dart-define=RUN_LIVE_API_TESTS=true
+flutter analyze --no-pub
+npm --prefix firebase_rules_tests ci
+firebase emulators:exec --only firestore,storage --project demo-elapse "npm --prefix firebase_rules_tests test"
+```
+
+`RUN_LIVE_API_TESTS` opts into read-only external requests using the configured token; it does not print the token. Without the opt-in, the live API test is skipped.
+
+## Not established by these checks
+
+Complete UI end-to-end coverage, real email verification/password reset, production Firebase deployment/configuration, release App Check enforcement, push notifications, real camera/photo permissions, offline/concurrent edit recovery, Android builds, physical-device behavior, and performance under load remain unverified. Passing unit and emulator tests alone does not establish production readiness.

--- a/elapse_app/firebase_rules_tests/rules.test.mjs
+++ b/elapse_app/firebase_rules_tests/rules.test.mjs
@@ -1,4 +1,5 @@
 import { after, before, beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 import {
@@ -8,6 +9,7 @@ import {
 } from '@firebase/rules-unit-testing';
 import {
   collection,
+  deleteDoc,
   doc,
   getDoc,
   getDocs,
@@ -16,8 +18,9 @@ import {
   setDoc,
   updateDoc,
   where,
+  writeBatch,
 } from 'firebase/firestore';
-import { getBytes, ref, uploadBytes } from 'firebase/storage';
+import { deleteObject, getBytes, ref, uploadBytes } from 'firebase/storage';
 
 const projectId = 'demo-elapse';
 const bucket = `gs://${projectId}.appspot.com`;
@@ -196,4 +199,79 @@ test('Storage accepts only small team-member image uploads', async () => {
       { contentType: 'image/png' },
     ),
   );
+});
+
+test('group lifecycle: create, join, save, reload, delete photo, leave and revoke access', async () => {
+  const alice = testEnvironment.authenticatedContext('alice', { email: 'alice@example.com' });
+  const bob = testEnvironment.authenticatedContext('bob', { email: 'bob@example.com' });
+  for (const [context, uid] of [[alice, 'alice'], [bob, 'bob']]) {
+    await assertSucceeds(setDoc(doc(context.firestore(), 'users', uid), {
+      email: `${uid}@example.com`, firstName: uid, lastName: 'Tester',
+      team: {}, groupId: [], verified: false,
+    }));
+  }
+  const db = alice.firestore();
+  const group = doc(db, 'teamGroups', 'lifecycle');
+  const create = writeBatch(db);
+  create.set(group, {
+    adminId: 'alice', groupName: 'Lifecycle', joinCode: 'TEST-1234',
+    allowJoin: true, members: { alice: 'Alice' },
+  });
+  create.update(doc(db, 'users', 'alice'), { groupId: ['lifecycle'] });
+  await assertSucceeds(create.commit());
+  const bobDb = bob.firestore();
+  const join = writeBatch(bobDb);
+  join.update(doc(bobDb, 'teamGroups', 'lifecycle'), { 'members.bob': 'Bob' });
+  join.update(doc(bobDb, 'users', 'bob'), { groupId: ['lifecycle'] });
+  await assertSucceeds(join.commit());
+
+  const sheetPath = ['teamGroups', 'lifecycle', 'scoutsheets', 'robot'];
+  await assertSucceeds(setDoc(doc(db, ...sheetPath), {
+    teamID: '10K', tournamentID: '64244', createTime: serverTimestamp(),
+    latestUpdate: serverTimestamp(), schemaVersion: 2,
+    template: { id: 'custom', name: 'Custom', fields: [{ id: 'notes', type: 'longText', label: 'Notes' }] },
+    answers: {}, photos: [], isEditing: true,
+  }));
+  await assertSucceeds(updateDoc(doc(bobDb, ...sheetPath), {
+    answers: { notes: 'Saved by teammate', score: 0, ready: false }, isEditing: false,
+  }));
+  assert.deepEqual((await getDoc(doc(db, ...sheetPath))).data().answers,
+    { notes: 'Saved by teammate', score: 0, ready: false });
+  await assertFails(updateDoc(doc(bobDb, ...sheetPath), { template: { id: 'replacement' } }));
+
+  const photoPath = 'teamGroups/lifecycle/scoutsheets/images/bob/robot.png';
+  const bobPhoto = ref(bob.storage(bucket), photoPath);
+  await assertSucceeds(uploadBytes(bobPhoto, new Uint8Array([137, 80, 78, 71]), { contentType: 'image/png' }));
+  await assertSucceeds(updateDoc(doc(bobDb, ...sheetPath), { photos: [photoPath] }));
+  assert.deepEqual((await getDoc(doc(db, ...sheetPath))).data().photos, [photoPath]);
+  await assertSucceeds(deleteObject(ref(alice.storage(bucket), photoPath)));
+  await assertSucceeds(updateDoc(doc(db, ...sheetPath), { photos: [] }));
+  assert.deepEqual((await getDoc(doc(bobDb, ...sheetPath))).data().photos, []);
+
+  const leave = writeBatch(db);
+  leave.update(group, { members: { bob: 'Bob' }, adminId: 'bob', allowJoin: false });
+  leave.update(doc(db, 'users', 'alice'), { groupId: [] });
+  await assertSucceeds(leave.commit());
+  await assertFails(getDoc(doc(db, ...sheetPath)));
+  await assertSucceeds(getDoc(doc(bobDb, ...sheetPath)));
+  await assertSucceeds(deleteDoc(doc(bobDb, ...sheetPath)));
+  const finish = writeBatch(bobDb);
+  finish.delete(doc(bobDb, 'teamGroups', 'lifecycle'));
+  finish.update(doc(bobDb, 'users', 'bob'), { groupId: [] });
+  await assertSucceeds(finish.commit());
+});
+
+test('security regression: joinable groups cannot be enumerated without a code', async () => {
+  await seedGroup({ allowJoin: true });
+  const outsider = testEnvironment.authenticatedContext('outsider').firestore();
+  await assertFails(getDocs(query(collection(outsider, 'teamGroups'), where('allowJoin', '==', true))));
+});
+
+test('security regression: an admin cannot erase unrelated memberships', async () => {
+  await seedGroup();
+  await testEnvironment.withSecurityRulesDisabled(async (context) => {
+    await setDoc(doc(context.firestore(), 'users', 'bob'), { groupId: ['group-1', 'unrelated-group'] });
+  });
+  const alice = testEnvironment.authenticatedContext('alice').firestore();
+  await assertFails(updateDoc(doc(alice, 'users', 'bob'), { groupId: [] }));
 });

--- a/elapse_app/lib/classes/ScoutSheet/scouted_sheet.dart
+++ b/elapse_app/lib/classes/ScoutSheet/scouted_sheet.dart
@@ -1,0 +1,43 @@
+import 'scout_sheet_data.dart';
+
+class ScoutedSheet {
+  const ScoutedSheet(
+      {required this.id,
+      required this.teamId,
+      required this.teamNumber,
+      required this.eventId,
+      required this.eventName,
+      required this.data,
+      this.updatedAt});
+
+  final String id;
+  final int teamId;
+  final String teamNumber;
+  final int eventId;
+  final String eventName;
+  final ScoutSheetData data;
+  final DateTime? updatedAt;
+
+  String get updatedLabel => updatedAt == null
+      ? '—'
+      : updatedAt!.toLocal().toIso8601String().substring(0, 10);
+
+  static String answerText(Object? value) {
+    if (value == null || value is String && value.trim().isEmpty) return '—';
+    if (value is bool) return value ? 'Yes' : 'No';
+    return value.toString();
+  }
+
+  /// Keep distinct questions distinct, even when their visible labels match.
+  Map<String, String> get answerColumns => {
+        for (final field in data.template.fields)
+          '${data.template.id}/${field.id}':
+              answerText(data.answerFor(field.id)),
+      };
+
+  Map<String, String> get columnLabels => {
+        for (final field in data.template.fields)
+          '${data.template.id}/${field.id}':
+              '${field.section} / ${field.label}',
+      };
+}

--- a/elapse_app/lib/classes/ScoutSheet/scouted_sheet_repository.dart
+++ b/elapse_app/lib/classes/ScoutSheet/scouted_sheet_repository.dart
@@ -1,0 +1,70 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:elapse_app/classes/Team/team.dart';
+import 'package:elapse_app/classes/Tournament/tournament_preview.dart';
+import 'package:elapse_app/classes/Filters/season.dart';
+import 'scout_sheet_data.dart';
+import 'scouted_sheet.dart';
+
+class ScoutedSheetPage {
+  const ScoutedSheetPage(this.sheets, {this.nextCursor});
+  final List<ScoutedSheet> sheets;
+  final Object? nextCursor;
+}
+
+class ScoutedSheetRepository {
+  final _teams = <int, Future<String>>{};
+  final _events = <int, Future<List<TournamentPreview>>>{};
+  static const pageSize = 25;
+
+  Future<ScoutedSheetPage> load(String groupId, Object? cursor) async {
+    var query = FirebaseFirestore.instance
+        .collection('teamGroups')
+        .doc(groupId)
+        .collection('scoutsheets')
+        .orderBy('latestUpdate', descending: true)
+        .limit(pageSize);
+    if (cursor is DocumentSnapshot) query = query.startAfterDocument(cursor);
+    final snapshot = await query.get().timeout(const Duration(seconds: 20));
+    final rows = <ScoutedSheet>[];
+    // Resolve a bounded page; cached metadata is shared by sheets for one team.
+    for (var offset = 0; offset < snapshot.docs.length; offset += 5) {
+      rows.addAll(
+          await Future.wait(snapshot.docs.skip(offset).take(5).map((doc) async {
+        final raw = doc.data();
+        final teamId = int.tryParse(raw['teamID']?.toString() ?? '') ?? 0;
+        final eventId =
+            int.tryParse(raw['tournamentID']?.toString() ?? '') ?? 0;
+        final number = await _teams.putIfAbsent(teamId, () async {
+          try {
+            return (await fetchTeam(teamId).timeout(const Duration(seconds: 8)))
+                    .teamNumber ??
+                'Team $teamId';
+          } on Object {
+            return 'Team $teamId';
+          }
+        });
+        final events = await _events.putIfAbsent(teamId, () async {
+          try {
+            return await fetchTeamTournaments(teamId, seasons.first.vrcId)
+                .timeout(const Duration(seconds: 8));
+          } on Object {
+            return <TournamentPreview>[];
+          }
+        });
+        final event = events.where((event) => event.id == eventId).firstOrNull;
+        final timestamp = raw['latestUpdate'];
+        return ScoutedSheet(
+            id: doc.id,
+            teamId: teamId,
+            teamNumber: number,
+            eventId: eventId,
+            eventName: event?.name ?? 'Event $eventId',
+            data: ScoutSheetData.fromFirestore(raw),
+            updatedAt: timestamp is Timestamp ? timestamp.toDate() : null);
+      })));
+    }
+    return ScoutedSheetPage(rows,
+        nextCursor:
+            snapshot.docs.length == pageSize ? snapshot.docs.last : null);
+  }
+}

--- a/elapse_app/lib/screens/scout/cloud_scout.dart
+++ b/elapse_app/lib/screens/scout/cloud_scout.dart
@@ -1,11 +1,15 @@
+import 'dart:convert';
+
 import 'package:elapse_app/classes/Team/teamPreview.dart';
 import 'package:elapse_app/classes/ScoutSheet/scout_template_repository.dart';
 import 'package:elapse_app/main.dart';
 import 'package:elapse_app/screens/scout/templates/scout_template_list.dart';
+import 'package:elapse_app/screens/scout/start_scouting.dart';
+import 'package:elapse_app/screens/scout/scouted_sheets.dart';
+import 'package:elapse_app/screens/team_screen/team_screen.dart';
 import 'package:elapse_app/screens/widgets/app_bar.dart';
 import 'package:elapse_app/screens/widgets/big_error_message.dart';
 import 'package:elapse_app/screens/widgets/rounded_top.dart';
-import 'package:elapse_app/screens/widgets/team_widget.dart';
 import 'package:flutter/material.dart';
 
 import '../tournament_mode/picklist/picklist.dart';
@@ -26,6 +30,24 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
     _templateRepository = ScoutTemplateRepository(prefs);
   }
 
+  void _openSheets() {
+    String? groupId;
+    try {
+      final group = jsonDecode(prefs.getString('teamGroup') ?? 'null');
+      if (group is Map) groupId = group['groupId'] as String?;
+    } on Object {/* The start flow can repair missing setup. */}
+    if (groupId == null || groupId.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text(
+              'No group selected yet. Tap Start scouting to sign in and set up your group.')));
+      return;
+    }
+    Navigator.push<void>(
+        context,
+        MaterialPageRoute(
+            builder: (_) => ScoutedSheetsScreen(groupId: groupId!)));
+  }
+
   @override
   Widget build(BuildContext context) {
     List<String> savedTeams = prefs.getStringList("savedTeams") ?? [];
@@ -41,6 +63,40 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
             settingsCallback: () => setState(() {}),
           ),
           RoundedTop(),
+          SliverToBoxAdapter(
+              child: Padding(
+            padding: const EdgeInsets.fromLTRB(23, 0, 23, 18),
+            child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const Text('Scout a team',
+                      style:
+                          TextStyle(fontSize: 24, fontWeight: FontWeight.w600)),
+                  const SizedBox(height: 8),
+                  const Text(
+                      'Choose a team and event, then fill in a sheet. Sheets are shared with your team group; templates are reusable blank forms.'),
+                  const SizedBox(height: 12),
+                  OutlinedButton.icon(
+                      onPressed: _openSheets,
+                      icon: const Icon(Icons.table_chart_outlined),
+                      label: const Text('My scout sheets')),
+                  const SizedBox(height: 8),
+                  FilledButton.icon(
+                    onPressed: () async {
+                      await Navigator.push<void>(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => StartScoutingScreen(
+                                template:
+                                    _templateRepository.loadDefaultTemplate()),
+                          ));
+                      if (mounted) setState(() {});
+                    },
+                    icon: const Icon(Icons.edit_note),
+                    label: const Text('Start scouting'),
+                  ),
+                ]),
+          )),
           SliverPadding(
             padding: const EdgeInsets.fromLTRB(23, 0, 23, 18),
             sliver: SliverToBoxAdapter(
@@ -57,7 +113,7 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
                   ),
                   title: const Text('Scout sheet templates'),
                   subtitle: Text(
-                    '${_templateRepository.loadTemplates().length} available • Create custom forms',
+                    '${_templateRepository.loadTemplates().length} blank forms • Use or customize a template',
                   ),
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () async {
@@ -143,7 +199,8 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
               ? SliverToBoxAdapter(
                   child: BigErrorMessage(
                       icon: Icons.bookmark_add_outlined,
-                      message: "Add some teams from the explore menu"),
+                      message:
+                          "No saved teams yet. Tap Start scouting to find any team—no bookmark needed."),
                 )
               : SliverPadding(
                   padding: EdgeInsets.symmetric(horizontal: 23),
@@ -154,12 +211,21 @@ class _CloudScoutScreenState extends State<CloudScoutScreen> {
                         print(savedTeam.teamName);
                         return Column(
                           children: [
-                            TeamWidget(
-                                teamNumber: savedTeam.teamNumber,
-                                teamID: savedTeam.teamID,
-                                subInfo:
-                                    '${savedTeam.location?.city ?? ""}${savedTeam.location?.city != null ? "," : ""} ${savedTeam.location?.region ?? ""}',
-                                teamName: savedTeam.teamName),
+                            ListTile(
+                              title: Text(savedTeam.teamNumber),
+                              subtitle: Text(
+                                  '${savedTeam.teamName ?? ''}\nOpen scout sheet'),
+                              isThreeLine: true,
+                              trailing: const Icon(Icons.chevron_right),
+                              onTap: () => Navigator.push<void>(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => TeamScreen(
+                                        teamID: savedTeam.teamID,
+                                        teamNumber: savedTeam.teamNumber,
+                                        openScoutSheet: true),
+                                  )),
+                            ),
                             Divider(
                               color: Theme.of(context).colorScheme.surfaceDim,
                               height: 3,

--- a/elapse_app/lib/screens/scout/scouted_sheets.dart
+++ b/elapse_app/lib/screens/scout/scouted_sheets.dart
@@ -1,0 +1,215 @@
+import 'package:elapse_app/classes/ScoutSheet/scouted_sheet.dart';
+import 'package:elapse_app/classes/ScoutSheet/scouted_sheet_repository.dart';
+import 'package:elapse_app/classes/Tournament/tournament_preview.dart';
+import 'package:elapse_app/main.dart';
+import 'package:elapse_app/screens/team_screen/team_screen.dart';
+import 'package:flutter/material.dart';
+
+class ScoutedSheetsScreen extends StatefulWidget {
+  const ScoutedSheetsScreen(
+      {super.key, required this.groupId, this.loadPage, this.onOpen});
+  final String groupId;
+  final Future<ScoutedSheetPage> Function(String, Object?)? loadPage;
+  final ValueChanged<ScoutedSheet>? onOpen;
+
+  @override
+  State<ScoutedSheetsScreen> createState() => _ScoutedSheetsScreenState();
+}
+
+class _ScoutedSheetsScreenState extends State<ScoutedSheetsScreen> {
+  final _repository = ScoutedSheetRepository();
+  List<ScoutedSheet> _sheets = [];
+  Object? _cursor;
+  bool _busy = false;
+  String? _error;
+  String _filter = '';
+  late bool _table;
+  bool _ascending = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _table = prefs.getBool('scoutSheets.tableView') ?? false;
+    _load();
+  }
+
+  Future<void> _load({bool more = false}) async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final page = await (widget.loadPage ?? _repository.load)(
+          widget.groupId, more ? _cursor : null);
+      if (!mounted) return;
+      setState(() {
+        final byId = {
+          if (more)
+            for (final sheet in _sheets) sheet.id: sheet,
+          for (final sheet in page.sheets) sheet.id: sheet
+        };
+        _sheets = byId.values.toList();
+        _cursor = page.nextCursor;
+      });
+    } on Object {
+      if (mounted)
+        setState(() => _error =
+            'Could not load your sheets. Check your connection and group access, then retry.');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _open(ScoutedSheet sheet) async {
+    if (widget.onOpen != null) {
+      widget.onOpen!(sheet);
+      return;
+    }
+    await Navigator.push<void>(
+        context,
+        MaterialPageRoute(
+            builder: (_) => TeamScreen(
+                  teamID: sheet.teamId,
+                  teamNumber: sheet.teamNumber,
+                  openScoutSheet: true,
+                  initialSheetId: sheet.id,
+                  initialEvent: TournamentPreview(
+                      id: sheet.eventId, name: sheet.eventName),
+                )));
+    if (mounted) await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = _sheets
+        .where((sheet) =>
+            '${sheet.teamNumber} ${sheet.eventName} ${sheet.data.template.name}'
+                .toLowerCase()
+                .contains(_filter.toLowerCase()))
+        .toList()
+      ..sort((a, b) => _ascending
+          ? a.teamNumber.compareTo(b.teamNumber)
+          : b.teamNumber.compareTo(a.teamNumber));
+    final fields =
+        {for (final sheet in visible) ...sheet.answerColumns.keys}.toList();
+    final labels = {for (final sheet in visible) ...sheet.columnLabels};
+    return Scaffold(
+      appBar: AppBar(title: const Text('My scout sheets'), actions: [
+        IconButton(
+            tooltip: 'Refresh sheets',
+            onPressed: _busy ? null : () => _load(),
+            icon: const Icon(Icons.refresh))
+      ]),
+      body: ListView(padding: const EdgeInsets.all(16), children: [
+        const Text(
+            'Saved in your team group. Open a row or card to review or edit that team’s sheet.'),
+        const SizedBox(height: 12),
+        SegmentedButton<bool>(
+            segments: const [
+              ButtonSegment(
+                  value: false,
+                  icon: Icon(Icons.view_list),
+                  label: Text('List')),
+              ButtonSegment(
+                  value: true,
+                  icon: Icon(Icons.table_chart_outlined),
+                  label: Text('Table')),
+            ],
+            selected: {
+              _table
+            },
+            onSelectionChanged: (selection) {
+              setState(() => _table = selection.single);
+              prefs.setBool('scoutSheets.tableView', _table);
+            }),
+        const SizedBox(height: 12),
+        TextField(
+            decoration: const InputDecoration(
+                labelText: 'Filter loaded sheets',
+                hintText: 'Team, event or template',
+                prefixIcon: Icon(Icons.search)),
+            onChanged: (value) => setState(() => _filter = value)),
+        const SizedBox(height: 12),
+        if (_busy) const LinearProgressIndicator(),
+        if (_error != null) ...[
+          Text(_error!),
+          TextButton(
+              onPressed: () =>
+                  _load(more: _sheets.isNotEmpty && _cursor != null),
+              child: const Text('Retry')),
+        ],
+        if (!_busy && _sheets.isEmpty && _error == null)
+          const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Text(
+                  'No scout sheets yet. Go back to Scout and tap Start scouting to create your first one.')),
+        if (_sheets.isNotEmpty && visible.isEmpty)
+          const Text('No loaded sheets match this filter.'),
+        if (visible.isNotEmpty && _table) ...[
+          const Text(
+              'Swipe horizontally for all answers. Tap a team to open its sheet.'),
+          SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                showCheckboxColumn: false,
+                sortColumnIndex: 0,
+                sortAscending: _ascending,
+                columns: [
+                  DataColumn(
+                      label: const Text('Team'),
+                      onSort: (_, ascending) =>
+                          setState(() => _ascending = ascending)),
+                  const DataColumn(label: Text('Event')),
+                  const DataColumn(label: Text('Template')),
+                  const DataColumn(label: Text('Updated')),
+                  for (final field in fields)
+                    DataColumn(
+                        label: SizedBox(
+                            width: 180,
+                            child: Text(labels[field] ?? field,
+                                maxLines: 2, overflow: TextOverflow.ellipsis))),
+                ],
+                rows: [
+                  for (final sheet in visible)
+                    DataRow(onSelectChanged: (_) => _open(sheet), cells: [
+                      DataCell(Text(sheet.teamNumber)),
+                      DataCell(Tooltip(
+                          message: sheet.eventName,
+                          child: SizedBox(
+                              width: 180,
+                              child: Text(sheet.eventName,
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis)))),
+                      DataCell(Text(sheet.data.template.name)),
+                      DataCell(Text(sheet.updatedLabel)),
+                      for (final field in fields)
+                        DataCell(Tooltip(
+                            message: sheet.answerColumns[field] ?? '—',
+                            child: SizedBox(
+                                width: 180,
+                                child: Text(sheet.answerColumns[field] ?? '—',
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis)))),
+                    ])
+                ],
+              )),
+        ],
+        if (!_table)
+          for (final sheet in visible)
+            Card(
+                child: ListTile(
+              title: Text(sheet.teamNumber),
+              subtitle: Text(
+                  '${sheet.eventName}\n${sheet.data.template.name} • ${sheet.updatedLabel}'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => _open(sheet),
+            )),
+        if (_cursor != null)
+          TextButton(
+              onPressed: _busy ? null : () => _load(more: true),
+              child: Text('Load more (${_sheets.length} loaded)')),
+      ]),
+    );
+  }
+}

--- a/elapse_app/lib/screens/scout/start_scouting.dart
+++ b/elapse_app/lib/screens/scout/start_scouting.dart
@@ -1,0 +1,142 @@
+import 'package:elapse_app/classes/ScoutSheet/scout_sheet_template.dart';
+import 'package:elapse_app/classes/Team/teamPreview.dart';
+import 'package:elapse_app/screens/team_screen/team_screen.dart';
+import 'package:flutter/material.dart';
+
+/// A template is a form definition, not a filled-in sheet. Select its subject
+/// before opening the event-specific sheet; never create cloud data on search.
+class StartScoutingScreen extends StatefulWidget {
+  const StartScoutingScreen({
+    super.key,
+    required this.template,
+    this.searchTeams = fetchTeamPreview,
+    this.onTeamSelected,
+  });
+
+  final ScoutSheetTemplate template;
+  final Future<List<TeamPreview>> Function(String) searchTeams;
+  final void Function(TeamPreview, ScoutSheetTemplate)? onTeamSelected;
+
+  @override
+  State<StartScoutingScreen> createState() => _StartScoutingScreenState();
+}
+
+class _StartScoutingScreenState extends State<StartScoutingScreen> {
+  final _query = TextEditingController();
+  List<TeamPreview> _teams = [];
+  bool _loading = false;
+  bool _searched = false;
+  String? _error;
+  int _request = 0;
+
+  @override
+  void dispose() {
+    _query.dispose();
+    super.dispose();
+  }
+
+  Future<void> _search() async {
+    final query = _query.text.trim().toUpperCase();
+    final request = ++_request;
+    if (query.isEmpty) {
+      setState(() {
+        _loading = false;
+        _teams = [];
+        _error = 'Enter a team number, like 1523W.';
+      });
+      return;
+    }
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _loading = true;
+      _error = null;
+      _teams = [];
+    });
+    try {
+      final teams = await widget.searchTeams(query);
+      if (!mounted || request != _request) return;
+      setState(() {
+        _teams = teams;
+        _searched = true;
+        _loading = false;
+      });
+    } on Object {
+      if (!mounted || request != _request) return;
+      setState(() {
+        _loading = false;
+        _error = 'Could not find teams. Check your connection and try again.';
+      });
+    }
+  }
+
+  void _openTeam(TeamPreview team) {
+    if (widget.onTeamSelected != null) {
+      widget.onTeamSelected!(team, widget.template);
+      return;
+    }
+    Navigator.pushReplacement<void, void>(
+        context,
+        MaterialPageRoute(
+            builder: (_) => TeamScreen(
+                  teamID: team.teamID,
+                  teamNumber: team.teamNumber,
+                  scoutTemplate: widget.template,
+                  openScoutSheet: true,
+                  returnAfterSave: true,
+                )));
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: const Text('Start scouting')),
+        body: ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            Text('1. Choose a team',
+                style: Theme.of(context).textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            Text('Using: ${widget.template.name}'),
+            const SizedBox(height: 8),
+            const Text(
+                'Next, choose an event and tap Create scout sheet. Your answers are saved with that team and event in your team group. Existing sheets keep their original template.'),
+            const SizedBox(height: 20),
+            TextField(
+              controller: _query,
+              textCapitalization: TextCapitalization.characters,
+              textInputAction: TextInputAction.search,
+              decoration: const InputDecoration(
+                  labelText: 'Team number',
+                  hintText: 'e.g. 1523W',
+                  border: OutlineInputBorder()),
+              onSubmitted: (_) => _search(),
+            ),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+                onPressed: _loading ? null : _search,
+                icon: const Icon(Icons.search),
+                label: const Text('Find team')),
+            if (_loading)
+              const Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Center(child: CircularProgressIndicator())),
+            if (_error != null)
+              Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  child: Text(_error!, semanticsLabel: _error)),
+            if (!_loading && _error == null && _searched && _teams.isEmpty)
+              const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 16),
+                  child: Text(
+                      'No teams found. Check the team number and try again.')),
+            for (final team in _teams)
+              Card(
+                  child: ListTile(
+                title: Text(team.teamNumber),
+                subtitle: Text(team.teamName ?? 'Open scout sheet'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => _openTeam(team),
+              )),
+          ],
+        ),
+      );
+}

--- a/elapse_app/lib/screens/scout/templates/scout_template_list.dart
+++ b/elapse_app/lib/screens/scout/templates/scout_template_list.dart
@@ -1,15 +1,18 @@
 import 'package:elapse_app/classes/ScoutSheet/scout_sheet_template.dart';
 import 'package:elapse_app/classes/ScoutSheet/scout_template_repository.dart';
 import 'package:elapse_app/screens/scout/templates/scout_template_editor.dart';
+import 'package:elapse_app/screens/scout/start_scouting.dart';
 import 'package:flutter/material.dart';
 
 class ScoutTemplateListScreen extends StatefulWidget {
   const ScoutTemplateListScreen({
     super.key,
     required this.repository,
+    this.onUseTemplate,
   });
 
   final ScoutTemplateRepository repository;
+  final ValueChanged<ScoutSheetTemplate>? onUseTemplate;
 
   @override
   State<ScoutTemplateListScreen> createState() =>
@@ -44,7 +47,7 @@ class _ScoutTemplateListScreenState extends State<ScoutTemplateListScreen> {
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 96),
         children: [
           Text(
-            'Pick a default or build reusable forms for different scouting jobs.',
+            'A template is a blank form. Tap Use template, choose a team, then create a scout sheet for an event and fill in your answers.',
             style: Theme.of(context).textTheme.bodyLarge,
           ),
           const SizedBox(height: 16),
@@ -53,6 +56,7 @@ class _ScoutTemplateListScreenState extends State<ScoutTemplateListScreen> {
               template: template,
               isDefault: template.id == _defaultTemplateId,
               onSetDefault: () => _setDefault(template),
+              onUse: () => _useTemplate(template),
               onEdit: template.isBuiltIn ? null : () => _openEditor(template),
               onDuplicate: () => _duplicate(template),
               onDelete: template.isBuiltIn ? null : () => _delete(template),
@@ -60,6 +64,18 @@ class _ScoutTemplateListScreenState extends State<ScoutTemplateListScreen> {
         ],
       ),
     );
+  }
+
+  void _useTemplate(ScoutSheetTemplate template) {
+    if (widget.onUseTemplate != null) {
+      widget.onUseTemplate!(template);
+    } else {
+      Navigator.pushReplacement<void, void>(
+          context,
+          MaterialPageRoute(
+            builder: (_) => StartScoutingScreen(template: template),
+          ));
+    }
   }
 
   Future<void> _openEditor([ScoutSheetTemplate? template]) async {
@@ -93,9 +109,13 @@ class _ScoutTemplateListScreenState extends State<ScoutTemplateListScreen> {
   }
 
   Future<void> _setDefault(ScoutSheetTemplate template) async {
-    await widget.repository.setDefaultTemplate(template.id);
-    if (!mounted) return;
-    setState(() => _defaultTemplateId = template.id);
+    try {
+      await widget.repository.setDefaultTemplate(template.id);
+      if (!mounted) return;
+      setState(() => _defaultTemplateId = template.id);
+    } on Object catch (error) {
+      if (mounted) _showError(error);
+    }
   }
 
   Future<void> _delete(ScoutSheetTemplate template) async {
@@ -137,6 +157,7 @@ class _TemplateCard extends StatelessWidget {
     required this.isDefault,
     required this.onSetDefault,
     required this.onDuplicate,
+    required this.onUse,
     this.onEdit,
     this.onDelete,
   });
@@ -145,6 +166,7 @@ class _TemplateCard extends StatelessWidget {
   final bool isDefault;
   final VoidCallback onSetDefault;
   final VoidCallback onDuplicate;
+  final VoidCallback onUse;
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
 
@@ -154,48 +176,52 @@ class _TemplateCard extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 12),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 6),
-        child: ListTile(
-          leading: Radio<String>(
-            value: template.id,
-            groupValue: isDefault ? template.id : null,
-            onChanged: (_) => onSetDefault(),
+        child: Column(children: [
+          ListTile(
+            onTap: onUse,
+            title: Text(template.name),
+            subtitle: Text(
+              '${template.fields.length} fields'
+              '${template.isBuiltIn ? ' • Built in' : ''}'
+              '${template.description.isEmpty ? '' : '\n${template.description}'}',
+            ),
+            isThreeLine: template.description.isNotEmpty,
+            trailing: PopupMenuButton<String>(
+              onSelected: (action) {
+                switch (action) {
+                  case 'edit':
+                    onEdit?.call();
+                  case 'duplicate':
+                    onDuplicate();
+                  case 'delete':
+                    onDelete?.call();
+                }
+              },
+              itemBuilder: (context) => [
+                if (onEdit != null)
+                  const PopupMenuItem(value: 'edit', child: Text('Edit')),
+                const PopupMenuItem(
+                    value: 'duplicate', child: Text('Duplicate')),
+                if (onDelete != null)
+                  const PopupMenuItem(value: 'delete', child: Text('Delete')),
+              ],
+            ),
           ),
-          onTap: onSetDefault,
-          title: Row(
-            children: [
-              Expanded(child: Text(template.name)),
-              if (template.isBuiltIn)
-                const Chip(
-                  label: Text('Built in'),
-                  visualDensity: VisualDensity.compact,
-                ),
-            ],
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
+            child: Wrap(spacing: 8, runSpacing: 4, children: [
+              FilledButton.icon(
+                  onPressed: onUse,
+                  icon: const Icon(Icons.edit_note),
+                  label: const Text('Use template')),
+              TextButton.icon(
+                  onPressed: isDefault ? null : onSetDefault,
+                  icon: Icon(isDefault ? Icons.star : Icons.star_border),
+                  label: Text(
+                      isDefault ? 'Default for new sheets' : 'Make default')),
+            ]),
           ),
-          subtitle: Text(
-            '${template.fields.length} fields'
-            '${template.description.isEmpty ? '' : '\n${template.description}'}',
-          ),
-          isThreeLine: template.description.isNotEmpty,
-          trailing: PopupMenuButton<String>(
-            onSelected: (action) {
-              switch (action) {
-                case 'edit':
-                  onEdit?.call();
-                case 'duplicate':
-                  onDuplicate();
-                case 'delete':
-                  onDelete?.call();
-              }
-            },
-            itemBuilder: (context) => [
-              if (onEdit != null)
-                const PopupMenuItem(value: 'edit', child: Text('Edit')),
-              const PopupMenuItem(value: 'duplicate', child: Text('Duplicate')),
-              if (onDelete != null)
-                const PopupMenuItem(value: 'delete', child: Text('Delete')),
-            ],
-          ),
-        ),
+        ]),
       ),
     );
   }

--- a/elapse_app/lib/screens/settings/group_settings.dart
+++ b/elapse_app/lib/screens/settings/group_settings.dart
@@ -11,6 +11,7 @@ import '../../extras/database.dart';
 import '../../main.dart';
 import '../widgets/app_bar.dart';
 import '../widgets/rounded_top.dart';
+import 'setup_group.dart';
 
 class GroupSettings extends StatefulWidget {
   const GroupSettings({
@@ -93,7 +94,21 @@ class _GroupSettingsState extends State<GroupSettings> {
                               message: "Error loading team group");
                         }
 
-                        TeamGroup group = snapshot.data as TeamGroup;
+                        final group = snapshot.data;
+                        if (group == null) {
+                          return Column(children: [
+                            const Text(
+                                'No group is available. If you just signed up, verify your email and return here. You can also create or join a group below.'),
+                            const SizedBox(height: 16),
+                            FilledButton(
+                                onPressed: () => Navigator.pushReplacement(
+                                    context,
+                                    MaterialPageRoute(
+                                        builder: (_) =>
+                                            const GroupSetupPage())),
+                                child: const Text('Create or join a group')),
+                          ]);
+                        }
 
                         return Column(children: [
                           Container(

--- a/elapse_app/lib/screens/settings/setup_group.dart
+++ b/elapse_app/lib/screens/settings/setup_group.dart
@@ -2,267 +2,167 @@ import 'dart:convert';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:pinput/pinput.dart';
 
 import '../../classes/Groups/teamGroup.dart';
 import '../../extras/database.dart';
 import '../../main.dart';
-import '../widgets/app_bar.dart';
-import '../widgets/long_button.dart';
-import '../widgets/rounded_top.dart';
-import 'create_group.dart';
 import 'group_settings.dart';
 
 class GroupSetupPage extends StatefulWidget {
-  const GroupSetupPage({super.key});
+  const GroupSetupPage(
+      {super.key,
+      this.returnToScouting = false,
+      this.createGroup,
+      this.joinGroup,
+      this.onComplete});
+
+  final bool returnToScouting;
+  final Future<TeamGroup?> Function(String)? createGroup;
+  final Future<TeamGroup?> Function(String)? joinGroup;
+  final ValueChanged<TeamGroup>? onComplete;
 
   @override
   State<GroupSetupPage> createState() => _GroupSetupPageState();
 }
 
 class _GroupSetupPageState extends State<GroupSetupPage> {
-  TextEditingController joinCodeController = TextEditingController();
+  final _name = TextEditingController();
+  final _code = TextEditingController();
+  bool _busy = false;
+  String? _error;
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-        body: CustomScrollView(slivers: [
-      ElapseAppBar(
-        title: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
-          GestureDetector(
-            onTap: () {
-              Navigator.pop(context);
-            },
-            child: const Icon(Icons.arrow_back),
-          ),
-          const SizedBox(width: 12),
-          Text('Setup',
-              style: TextStyle(
-                fontSize: 24,
-                fontFamily: 'Manrope',
-                fontWeight: FontWeight.w500,
-                color: Theme.of(context).colorScheme.onSurface,
-              )),
-        ]),
-        maxHeight: 60,
-      ),
-      const RoundedTop(),
-      SliverPadding(
-          padding: const EdgeInsets.only(left: 23, right: 23, bottom: 23),
-          sliver: SliverToBoxAdapter(
-              child: Column(children: [
-            const SizedBox(
-              width: double.infinity,
-              child: Text("Join a Group",
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.w500)),
-            ),
-            const SizedBox(height: 18),
-            Text(
-                "If your team has already created a group, ask a group member for the join code. You can then enter the join code to join the group.",
-                style: TextStyle(fontSize: 14, fontWeight: FontWeight.w300)),
-            const SizedBox(height: 24),
-            Pinput(
-                length: 8,
-                controller: joinCodeController,
-                defaultPinTheme: PinTheme(
-                    width: 45,
-                    height: 45,
-                    textStyle: TextStyle(fontSize: 24),
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                          color: Theme.of(context).colorScheme.onSurface),
-                      borderRadius: BorderRadius.circular(9),
-                    )),
-                focusedPinTheme: PinTheme(
-                    width: 45,
-                    height: 45,
-                    textStyle: TextStyle(fontSize: 24),
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                          color: Theme.of(context).colorScheme.primary),
-                      borderRadius: BorderRadius.circular(9),
-                    )),
-                separatorBuilder: (index) {
-                  if (index == 3) {
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 5),
-                      child: Text("—",
-                          style: TextStyle(
-                              fontSize: 36, fontWeight: FontWeight.w300)),
-                    );
-                  }
-                  return const SizedBox(width: 5);
-                },
-                showCursor: false,
-                keyboardType: TextInputType.text,
-                textCapitalization: TextCapitalization.characters,
-                inputFormatters: [
-                  FilteringTextInputFormatter.allow(RegExp("[0-9a-zA-Z]")),
-                  TextInputFormatter.withFunction((oldVal, newVal) {
-                    return TextEditingValue(
-                      text: newVal.text.toUpperCase(),
-                      selection: newVal.selection,
-                    );
-                  }),
-                ]),
-            const SizedBox(height: 18),
-            LongButton(
-              onPressed: () async {
-                Database database = Database();
-                final currentUser = FirebaseAuth.instance.currentUser;
-                TeamGroup group = TeamGroup.fromJson((await database.getGroupInfo(
-                    "${joinCodeController.text.substring(0, 4)}-${joinCodeController.text.substring(4)}"))!);
-                if (!group.allowJoin) {
-                  showDialog(
-                      barrierDismissible: false,
-                      context: context,
-                      builder: (context) {
-                        return AlertDialog(
-                          title: Text("Unable to Join"),
-                          content: Text(
-                              "This Team Group does not allow others to join."),
-                          actions: [
-                            TextButton(
-                                onPressed: () {
-                                  Navigator.pop(context);
-                                },
-                                child: Text(
-                                  "Close",
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .secondary),
-                                ))
-                          ],
-                        );
-                      });
-                  return;
-                }
-
-                await database
-                    .joinTeamGroup(
-                        "${joinCodeController.text.substring(0, 4)}-${joinCodeController.text.substring(4)}",
-                        currentUser!.uid)
-                    .then((value) async {
-                  if (value == null) {
-                    await showDialog(
-                        context: context,
-                        builder: (context) {
-                          return AlertDialog(
-                            title: const Text("Invalid Join Code"),
-                            content: const Text(
-                                "Unable to find a team group with this join code."),
-                            contentPadding: const EdgeInsets.symmetric(
-                                horizontal: 24, vertical: 10),
-                            actions: [
-                              TextButton(
-                                child: Text("Close",
-                                    style: TextStyle(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .secondary)),
-                                onPressed: () => Navigator.pop(context),
-                              ),
-                            ],
-                            actionsPadding:
-                                const EdgeInsets.only(bottom: 8, right: 16),
-                            shape: RoundedRectangleBorder(
-                                side: BorderSide(
-                                    color:
-                                        Theme.of(context).colorScheme.primary),
-                                borderRadius: BorderRadius.circular(18)),
-                          );
-                        });
-                    setState(() {
-                      joinCodeController.text = "";
-                    });
-                    return;
-                  }
-                  prefs.setString("teamGroup", jsonEncode(value.toJson()));
-                  Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) =>
-                            GroupSettings(uid: currentUser.uid),
-                      ));
-                }).catchError((onError) {
-                  showDialog(
-                      barrierDismissible: false,
-                      context: context,
-                      builder: (context) {
-                        return AlertDialog(
-                          title: Text("Error Occurred"),
-                          content: Text(
-                              "An error occurred when creating joining the team group, please try again"),
-                          actions: [
-                            TextButton(
-                                onPressed: () {
-                                  Navigator.pop(context);
-                                },
-                                child: Text(
-                                  "Cancel",
-                                  style: TextStyle(
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .secondary),
-                                ))
-                          ],
-                        );
-                      });
-                });
-              },
-              text: "Join the Group",
-              gradient: true,
-            ),
-            Padding(
-                padding: const EdgeInsets.symmetric(vertical: 23),
-                child: Row(children: [
-                  Expanded(
-                    child: Container(
-                        margin: const EdgeInsets.only(right: 18),
-                        child: Divider(
-                          color: Theme.of(context).colorScheme.surfaceDim,
-                          height: 36,
-                        )),
-                  ),
-                  Text("OR",
-                      style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w300,
-                          color:
-                              Theme.of(context).colorScheme.onSurfaceVariant)),
-                  Expanded(
-                    child: Container(
-                        margin: const EdgeInsets.only(left: 18),
-                        child: Divider(
-                          color: Theme.of(context).colorScheme.surfaceDim,
-                          height: 36,
-                        )),
-                  ),
-                ])),
-            const SizedBox(
-              width: double.infinity,
-              child: Text("Create a Group",
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.w500)),
-            ),
-            const SizedBox(height: 18),
-            Text(
-                "If you do not have a group to join, you can create a new group.",
-                style: TextStyle(fontSize: 14, fontWeight: FontWeight.w300)),
-            const SizedBox(height: 18),
-            LongButton(
-              onPressed: () {
-                Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => GroupCreatePage(),
-                    ));
-              },
-              text: "Create a New Group",
-              gradient: true,
-            ),
-          ])))
-    ]));
+  void dispose() {
+    _name.dispose();
+    _code.dispose();
+    super.dispose();
   }
+
+  Future<void> _submit({required bool join}) async {
+    if (_busy) return;
+    final name = _name.text.trim();
+    final code = _code.text.replaceAll(RegExp(r'[\s-]'), '').toUpperCase();
+    if (join
+        ? !RegExp(r'^[A-Z0-9]{8}$').hasMatch(code)
+        : name.isEmpty || name.length > 80) {
+      setState(() => _error = join
+          ? 'Enter the 8-letter/digit invite code, like ABCD-1234.'
+          : 'Enter a group name (1–80 characters).');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final normalized =
+          join ? '${code.substring(0, 4)}-${code.substring(4)}' : name;
+      final handler = join ? widget.joinGroup : widget.createGroup;
+      TeamGroup? group;
+      if (handler != null) {
+        group = await handler(normalized);
+      } else {
+        final user = FirebaseAuth.instance.currentUser;
+        if (user == null)
+          throw StateError('Sign in before creating or joining a group.');
+        final db = Database();
+        if (join) {
+          group = await db.joinTeamGroup(normalized, user.uid);
+        } else {
+          final profile = await db.getUserInfo(user.uid);
+          if (profile == null)
+            throw StateError(
+                'Could not load your account. Check your connection, then try again.');
+          group = await db.createTeamGroup(
+              user.uid,
+              name,
+              profile['firstName']?.toString() ?? 'Scout',
+              profile['lastName']?.toString() ?? '');
+        }
+      }
+      if (!mounted) return;
+      if (group == null || group.groupId == null) {
+        throw StateError(join
+            ? 'Could not join. Check the invite code, your connection, and whether the group accepts new members.'
+            : 'Could not create the group. Check your connection and try again.');
+      }
+      if (!await prefs.setString('teamGroup', jsonEncode(group.toJson()))) {
+        throw StateError(
+            'Your group was saved online, but could not be selected on this device. Reopen Settings to select it.');
+      }
+      if (!mounted) return;
+      if (widget.onComplete != null) {
+        widget.onComplete!(group);
+      } else if (widget.returnToScouting) {
+        Navigator.pop(context, group);
+      } else {
+        Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(
+                builder: (_) => GroupSettings(
+                    uid: FirebaseAuth.instance.currentUser!.uid)));
+      }
+    } on Object catch (error) {
+      if (mounted)
+        setState(
+            () => _error = error.toString().replaceFirst('Bad state: ', ''));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => PopScope(
+        canPop: !_busy,
+        child: Scaffold(
+          appBar: AppBar(title: const Text('Save with a group')),
+          body: ListView(padding: const EdgeInsets.all(20), children: [
+            const Text(
+                'A group is where your scout sheets live. You can create one just for yourself—you do not need an invite code or teammates.'),
+            const SizedBox(height: 20),
+            Text('New to scouting? Start here',
+                style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 12),
+            TextField(
+                controller: _name,
+                enabled: !_busy,
+                maxLength: 80,
+                decoration: const InputDecoration(
+                    labelText: 'Group name',
+                    hintText: 'e.g. My scouting notebook',
+                    border: OutlineInputBorder()),
+                onSubmitted: (_) => _submit(join: false)),
+            FilledButton(
+                onPressed: _busy ? null : () => _submit(join: false),
+                child: Text(widget.returnToScouting
+                    ? 'Create group & continue scouting'
+                    : 'Create group')),
+            const SizedBox(height: 20),
+            ExpansionTile(
+                title: const Text('Already have an invite code?'),
+                children: [
+                  TextField(
+                      controller: _code,
+                      enabled: !_busy,
+                      textCapitalization: TextCapitalization.characters,
+                      decoration: const InputDecoration(
+                          labelText: 'Invite code', hintText: 'ABCD-1234'),
+                      onSubmitted: (_) => _submit(join: true)),
+                  OutlinedButton(
+                      onPressed: _busy ? null : () => _submit(join: true),
+                      child: const Text('Join group')),
+                ]),
+            if (_busy)
+              const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(child: CircularProgressIndicator())),
+            if (_error != null)
+              Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: Text(_error!,
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.error))),
+          ]),
+        ),
+      );
 }

--- a/elapse_app/lib/screens/team_screen/scoutsheet/empty.dart
+++ b/elapse_app/lib/screens/team_screen/scoutsheet/empty.dart
@@ -1,7 +1,8 @@
 import 'package:elapse_app/screens/widgets/long_button.dart';
 import 'package:flutter/material.dart';
 
-List<Widget> EmptyState(BuildContext context, void Function() onPressed) {
+List<Widget> EmptyState(BuildContext context, void Function() onPressed,
+    {String? templateName}) {
   return [
     SliverToBoxAdapter(
       child: Container(
@@ -15,17 +16,19 @@ List<Widget> EmptyState(BuildContext context, void Function() onPressed) {
         margin: EdgeInsets.only(left: 23, right: 23, top: 8),
         padding: EdgeInsets.all(18),
         alignment: Alignment.center,
-        child: const Column(
+        child: Column(
           children: [
             Icon(Icons.dynamic_form_outlined, size: 40),
             SizedBox(height: 10),
             Text(
-              'Nothing here yet',
+              'Ready to scout this team?',
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
             ),
             SizedBox(height: 4),
             Text(
-              'Choose a template to start scouting this team.',
+              templateName == null
+                  ? 'Create a sheet, choose your form, and start answering. You can reopen it from this team’s Scout sheet tab.'
+                  : 'Create a sheet using $templateName and start answering. You can reopen it from this team’s Scout sheet tab.',
               textAlign: TextAlign.center,
             ),
           ],

--- a/elapse_app/lib/screens/team_screen/team_page_header.dart
+++ b/elapse_app/lib/screens/team_screen/team_page_header.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Use the toolbar's leading/title slots, never overlay two back controls in
+/// flexibleSpace. Their layout stays disjoint while scrolling and scaling text.
+class TeamPageHeader extends StatelessWidget {
+  const TeamPageHeader(
+      {super.key, required this.teamNumber, required this.onSeason});
+  final String teamNumber;
+  final VoidCallback onSeason;
+
+  @override
+  Widget build(BuildContext context) => SliverAppBar(
+        pinned: true,
+        leading: BackButton(onPressed: () => Navigator.maybePop(context)),
+        title: Text('Team $teamNumber',
+            maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: [
+          IconButton(
+              tooltip: 'Change season',
+              onPressed: onSeason,
+              icon: const Icon(Icons.event_note))
+        ],
+      );
+}

--- a/elapse_app/lib/screens/team_screen/team_screen.dart
+++ b/elapse_app/lib/screens/team_screen/team_screen.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:elapse_app/setup/signup/login_or_signup.dart';
 import 'package:elapse_app/classes/Filters/season.dart';
 import 'package:elapse_app/classes/Miscellaneous/location.dart';
 import 'package:elapse_app/classes/ScoutSheet/scout_sheet_data.dart';
@@ -21,7 +23,7 @@ import 'package:elapse_app/screens/team_screen/details/details.dart';
 import 'package:elapse_app/screens/team_screen/scoutsheet/closed.dart';
 import 'package:elapse_app/screens/team_screen/scoutsheet/edit.dart';
 import 'package:elapse_app/screens/team_screen/scoutsheet/empty.dart';
-import 'package:elapse_app/screens/widgets/app_bar.dart';
+import 'package:elapse_app/screens/team_screen/team_page_header.dart';
 import 'package:elapse_app/screens/widgets/custom_tab_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:elapse_app/main.dart';
@@ -32,10 +34,23 @@ import '../widgets/long_button.dart';
 
 class TeamScreen extends StatefulWidget {
   const TeamScreen(
-      {super.key, required this.teamID, required this.teamNumber, this.team});
+      {super.key,
+      required this.teamID,
+      required this.teamNumber,
+      this.team,
+      this.scoutTemplate,
+      this.openScoutSheet = false,
+      this.returnAfterSave = false,
+      this.initialSheetId,
+      this.initialEvent});
   final int teamID;
   final String teamNumber;
   final Team? team;
+  final ScoutSheetTemplate? scoutTemplate;
+  final bool openScoutSheet;
+  final bool returnAfterSave;
+  final String? initialSheetId;
+  final TournamentPreview? initialEvent;
 
   @override
   State<TeamScreen> createState() => _TeamScreenState();
@@ -64,12 +79,16 @@ class _TeamScreenState extends State<TeamScreen> {
   final Database database = Database();
   late final ScoutTemplateRepository _templateRepository;
   Timer? _saveDebounce;
-  bool _savingAnswers = false;
+  Future<void>? _answerSave;
   String scoutsheetID = "";
+  bool _loadingSheet = false;
+  String? _sheetLoadError;
+  bool _initialEventPending = true;
 
   @override
   void initState() {
     super.initState();
+    pageIndex = widget.openScoutSheet ? 1 : 0;
     _templateRepository = ScoutTemplateRepository(prefs);
     teamGroupID = _readTeamGroupId();
     activeScoutSheet = ScoutSheetData.empty(
@@ -147,17 +166,31 @@ class _TeamScreenState extends State<TeamScreen> {
   Future<List<TournamentPreview>> _fetchTournamentsForSeason(
     Season requestedSeason,
   ) async {
-    final tournaments = await fetchTeamTournaments(
-      widget.teamID,
-      requestedSeason.vrcId,
-    );
+    final tournaments = <TournamentPreview>[];
+    try {
+      tournaments.addAll(await fetchTeamTournaments(
+        widget.teamID,
+        requestedSeason.vrcId,
+      ));
+    } on Object {
+      if (widget.initialEvent == null || !_initialEventPending) rethrow;
+    }
     if (!mounted || season.vrcId != requestedSeason.vrcId) return tournaments;
 
-    final firstTournament = tournaments.isEmpty
-        ? TournamentPreview(id: 0, name: '')
-        : tournaments.first;
+    final requestedEvent = _initialEventPending ? widget.initialEvent : null;
+    _initialEventPending = false;
+    if (requestedEvent != null &&
+        !tournaments.any((event) => event.id == requestedEvent.id)) {
+      tournaments.insert(0, requestedEvent);
+    }
+    final firstTournament = requestedEvent ??
+        (tournaments.isEmpty
+            ? TournamentPreview(id: 0, name: '')
+            : tournaments.first);
     setState(() {
-      selectedTournamentIndex = 0;
+      selectedTournamentIndex = tournaments.isEmpty
+          ? 0
+          : tournaments.indexWhere((event) => event.id == firstTournament.id);
       selectedTournament = firstTournament;
       scoutsheetID = '';
       scoutSheetStateIndex = 0;
@@ -174,22 +207,39 @@ class _TeamScreenState extends State<TeamScreen> {
   Future<void> _loadScoutSheet(TournamentPreview tournament) async {
     if (teamGroupID.isEmpty || tournament.id == 0) return;
     final requestedTournamentId = tournament.id;
+    setState(() {
+      _loadingSheet = true;
+      _sheetLoadError = null;
+    });
     final DocumentSnapshot<Object?>? document;
     try {
-      document = await database.getTeamScoutSheetInfo(
-        teamGroupID,
-        widget.teamID.toString(),
-        requestedTournamentId.toString(),
-      );
+      document = widget.initialSheetId != null &&
+              requestedTournamentId == widget.initialEvent?.id
+          ? await FirebaseFirestore.instance
+              .collection('teamGroups')
+              .doc(teamGroupID)
+              .collection('scoutsheets')
+              .doc(widget.initialSheetId)
+              .get()
+          : await database.getTeamScoutSheetInfo(
+              teamGroupID,
+              widget.teamID.toString(),
+              requestedTournamentId.toString(),
+            );
     } on Object {
       if (mounted && selectedTournament.id == requestedTournamentId) {
-        _showError('Could not load this scout sheet.');
+        setState(() => _sheetLoadError =
+            'Could not load this sheet. Retry before creating a new one.');
       }
       return;
+    } finally {
+      if (mounted && selectedTournament.id == requestedTournamentId) {
+        setState(() => _loadingSheet = false);
+      }
     }
     if (!mounted || selectedTournament.id != requestedTournamentId) return;
 
-    if (document == null) {
+    if (document == null || !document.exists) {
       setState(() {
         scoutsheetID = '';
         scoutSheetStateIndex = 0;
@@ -216,7 +266,7 @@ class _TeamScreenState extends State<TeamScreen> {
     List<TournamentPreview> tournaments,
     int tournamentId,
   ) async {
-    await _flushAnswerSave();
+    if (!await _flushAnswerSave()) return;
     final index = tournaments.indexWhere((event) => event.id == tournamentId);
     if (index < 0 || !mounted) return;
     setState(() {
@@ -303,10 +353,15 @@ class _TeamScreenState extends State<TeamScreen> {
     );
   }
 
-  Future<void> _flushAnswerSave() async {
+  Future<bool> _flushAnswerSave() async {
     _saveDebounce?.cancel();
-    if (_savingAnswers || scoutsheetID.isEmpty) return;
-    _savingAnswers = true;
+    if (_answerSave != null) {
+      await _answerSave;
+      return _flushAnswerSave();
+    }
+    if (scoutsheetID.isEmpty) return true;
+    final completion = Completer<void>();
+    _answerSave = completion.future;
     final sheetId = scoutsheetID;
     final answers = activeScoutSheet.answers;
     try {
@@ -315,12 +370,15 @@ class _TeamScreenState extends State<TeamScreen> {
         sheetId,
         answers,
       );
+      return true;
     } on Object {
       if (mounted && sheetId == scoutsheetID) {
         _showError('Answers could not be saved. Check your connection.');
       }
+      return false;
     } finally {
-      _savingAnswers = false;
+      _answerSave = null;
+      completion.complete();
       if (mounted &&
           sheetId == scoutsheetID &&
           !identical(answers, activeScoutSheet.answers)) {
@@ -339,8 +397,18 @@ class _TeamScreenState extends State<TeamScreen> {
   }
 
   Future<void> _createScoutSheet() async {
-    final template = await _pickTemplate();
+    if (_loadingSheet || _sheetLoadError != null) return;
+    final template = widget.scoutTemplate ?? await _pickTemplate();
     if (template == null || !mounted) return;
+
+    await _createScoutSheetWithTemplate(template);
+  }
+
+  Future<void> _createScoutSheetWithTemplate(
+      ScoutSheetTemplate template) async {
+    if (teamGroupID.isEmpty ||
+        selectedTournament.id == 0 ||
+        scoutsheetID.isNotEmpty) return;
 
     showDialog<void>(
       barrierDismissible: false,
@@ -370,6 +438,8 @@ class _TeamScreenState extends State<TeamScreen> {
         activeScoutSheet = ScoutSheetData.empty(template);
         scoutSheetStateIndex = 2;
       });
+      // Make the new sheet's team easy to reopen from the Scout tab.
+      if (!isSaved) toggleSaveTeam();
     } on Object {
       if (!mounted) return;
       Navigator.of(context, rootNavigator: true).pop();
@@ -422,15 +492,22 @@ class _TeamScreenState extends State<TeamScreen> {
   }
 
   Future<void> _openTemplateManager() async {
-    await Navigator.push<void>(
+    final selected = await Navigator.push<ScoutSheetTemplate>(
       context,
       MaterialPageRoute(
         builder: (context) => ScoutTemplateListScreen(
           repository: _templateRepository,
+          onUseTemplate: (template) => Navigator.pop(context, template),
         ),
       ),
     );
     if (!mounted || scoutsheetID.isNotEmpty) return;
+    if (selected != null &&
+        selectedTournament.id != 0 &&
+        teamGroupID.isNotEmpty) {
+      await _createScoutSheetWithTemplate(selected);
+      return;
+    }
     setState(() {
       activeScoutSheet = ScoutSheetData.empty(
         _templateRepository.loadDefaultTemplate(),
@@ -474,9 +551,19 @@ class _TeamScreenState extends State<TeamScreen> {
         activeScoutSheet.photos,
         updateSheet,
         activeScoutSheet);
-    List<Widget> ScoutSheetEmpty =
-        selectedTournament.id != 0 && teamGroupID.isNotEmpty
-            ? EmptyState(context, _createScoutSheet)
+    List<Widget> ScoutSheetEmpty = selectedTournament.id != 0 &&
+            teamGroupID.isNotEmpty
+        ? EmptyState(context, _createScoutSheet,
+            templateName: widget.scoutTemplate?.name)
+        : teamGroupID.isNotEmpty
+            ? [
+                const SliverToBoxAdapter(
+                    child: Padding(
+                  padding: EdgeInsets.all(23),
+                  child: Text(
+                      'Choose an event above to start a sheet. If no events are listed, try another season using the season selector at the top.'),
+                ))
+              ]
             : [
                 SliverToBoxAdapter(
                   child: Container(
@@ -493,17 +580,38 @@ class _TeamScreenState extends State<TeamScreen> {
                     child: Column(children: [
                       BigErrorMessage(
                         icon: Icons.people_alt_outlined,
-                        message: "Not in a team group",
+                        message: FirebaseAuth.instance.currentUser == null
+                            ? 'Sign in to save scout sheets'
+                            : 'Set up your group to save scout sheets',
                         topPadding: 0,
                         textPadding: 5,
                       ),
                       const SizedBox(height: 18),
+                      const Text(
+                          'Scout sheets are shared with your team group. Create a group or join your teammates, then return here to start this sheet.',
+                          textAlign: TextAlign.center),
+                      const SizedBox(height: 18),
                       LongButton(
                           onPressed: () async {
+                            if (FirebaseAuth.instance.currentUser == null) {
+                              await Navigator.push<void>(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => const SignUpPage(),
+                                  ));
+                              if (!context.mounted) return;
+                              setState(() => teamGroupID = _readTeamGroupId());
+                              if (teamGroupID.isNotEmpty &&
+                                  selectedTournament.id != 0) {
+                                await _loadScoutSheet(selectedTournament);
+                              }
+                              return;
+                            }
                             await Navigator.push(
                                 context,
                                 MaterialPageRoute(
-                                    builder: (context) => GroupSetupPage()));
+                                    builder: (context) => const GroupSetupPage(
+                                        returnToScouting: true)));
                             if (!context.mounted) return;
                             setState(() {
                               teamGroupID = _readTeamGroupId();
@@ -513,7 +621,9 @@ class _TeamScreenState extends State<TeamScreen> {
                               await _loadScoutSheet(selectedTournament);
                             }
                           },
-                          text: "Set Up a Team Group")
+                          text: FirebaseAuth.instance.currentUser == null
+                              ? 'Sign in or create account'
+                              : 'Set up a team group')
                     ]),
                   ),
                 )
@@ -529,8 +639,8 @@ class _TeamScreenState extends State<TeamScreen> {
 
     switch (scoutSheetStateIndex) {
       case 1:
-        button = IconButton(
-          tooltip: 'Edit scout sheet',
+        button = FilledButton.icon(
+          label: const Text('Edit sheet'),
           onPressed: () async {
             if (scoutsheetID.isEmpty) return;
             try {
@@ -548,27 +658,31 @@ class _TeamScreenState extends State<TeamScreen> {
             Icons.edit_outlined,
             color: Theme.of(context).colorScheme.secondary,
           ),
-          padding: EdgeInsets.all(8),
-          constraints: BoxConstraints(),
         );
         break;
       case 2:
-        button = IconButton(
-          tooltip: 'Finish editing',
+        button = FilledButton.icon(
+          label: const Text('Save sheet'),
           onPressed: () async {
             final missing = activeScoutSheet.missingRequiredFields;
             if (missing.isNotEmpty) {
               _showError('Complete required field: ${missing.first.label}');
               return;
             }
-            await _flushAnswerSave();
+            if (!await _flushAnswerSave() || !mounted) return;
             try {
               await database.setTeamScoutSheetEditing(
                 teamGroupID,
                 scoutsheetID,
                 false,
               );
-              if (mounted) setState(() => scoutSheetStateIndex = 1);
+              if (mounted) {
+                setState(() => scoutSheetStateIndex = 1);
+                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                    content: Text(
+                        'Sheet saved. Reopen it from Scout → My scout sheets.')));
+                if (widget.returnAfterSave) Navigator.pop(context);
+              }
             } on Object {
               if (mounted) _showError('Could not finish editing.');
             }
@@ -577,8 +691,6 @@ class _TeamScreenState extends State<TeamScreen> {
             Icons.check,
             color: Theme.of(context).colorScheme.secondary,
           ),
-          padding: EdgeInsets.all(8),
-          constraints: BoxConstraints(),
         );
         break;
       default:
@@ -598,6 +710,20 @@ class _TeamScreenState extends State<TeamScreen> {
     }
 
     List<Widget> ScoutSheetScreen = [
+      SliverToBoxAdapter(
+          child: Padding(
+        padding: const EdgeInsets.fromLTRB(23, 8, 23, 12),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text('Scout ${widget.teamNumber}',
+              style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 4),
+          Text(scoutSheetStateIndex == 2
+              ? 'Fill in the fields below, then tap Save sheet. Changes also save to your team group as you type.'
+              : scoutsheetID.isNotEmpty
+                  ? 'Saved sheet • ${activeScoutSheet.template.name}. Tap Edit sheet to add notes. Choose another event below to view its sheet.'
+                  : '2. Choose an event below, then create your sheet.${widget.scoutTemplate == null ? '' : '\nTemplate: ${widget.scoutTemplate!.name}'}'),
+        ]),
+      )),
       SliverToBoxAdapter(
         child: Padding(
           padding: const EdgeInsets.only(left: 23.0, right: 11),
@@ -705,73 +831,73 @@ class _TeamScreenState extends State<TeamScreen> {
                         ),
                 ),
               ),
-              Flexible(flex: 2, fit: FlexFit.tight, child: SizedBox()),
-              Flexible(fit: FlexFit.tight, child: button)
             ],
           ),
         ),
       ),
     ];
 
-    ScoutSheetScreen.addAll(ScoutSheetScreens[scoutSheetStateIndex]);
+    if (scoutSheetStateIndex != 0) {
+      ScoutSheetScreen.add(SliverToBoxAdapter(
+          child: Padding(
+        padding: const EdgeInsets.fromLTRB(23, 12, 23, 8),
+        child: button,
+      )));
+    }
+    if (_loadingSheet) {
+      ScoutSheetScreen.add(const SliverToBoxAdapter(
+          child: Padding(
+        padding: EdgeInsets.all(23),
+        child: LinearProgressIndicator(),
+      )));
+    } else if (_sheetLoadError != null) {
+      ScoutSheetScreen.add(SliverToBoxAdapter(
+          child: Padding(
+        padding: const EdgeInsets.all(23),
+        child: Column(children: [
+          Text(_sheetLoadError!),
+          TextButton(
+              onPressed: () => _loadScoutSheet(selectedTournament),
+              child: const Text('Retry loading sheet')),
+        ]),
+      )));
+    } else {
+      ScoutSheetScreen.addAll(ScoutSheetScreens[scoutSheetStateIndex]);
+    }
+    if (scoutSheetStateIndex == 2) {
+      ScoutSheetScreen.add(SliverToBoxAdapter(
+          child: Padding(
+        padding: const EdgeInsets.all(23),
+        child: button,
+      )));
+    }
 
     List<List<Widget>> screens = [DetailsScreen, ScoutSheetScreen];
 
     List<Widget> MainSlivers = [
-      ElapseAppBar(
-        title: const Text(
-          "Team Info",
-          style: TextStyle(fontSize: 24, fontWeight: FontWeight.w600),
-        ),
-        backNavigation: true,
-        background: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.5),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              GestureDetector(
-                onTap: () {
-                  Navigator.pop(context);
-                },
-                child: Icon(Icons.arrow_back,
-                    color: Theme.of(context).colorScheme.onSurface),
-              ),
-              const Spacer(),
-              GestureDetector(
-                  onTap: () async {
-                    final updated = await Navigator.push<Season>(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) =>
-                            SeasonFilterPage(selected: season),
-                      ),
-                    );
-                    if (updated == null || !context.mounted) return;
-                    setState(() {
-                      season = updated;
-                      skillsStats =
-                          getWorldSkillsForTeam(season.vrcId, widget.teamID);
-                      teamStats = getTrueSkillDataForTeam(
-                          season.vrcId, widget.teamNumber);
-                      teamTournaments = _fetchTournamentsForSeason(season);
-                      teamAwards = getAwards(widget.teamID, season.vrcId);
-                    });
-                  },
-                  child: Row(children: [
-                    const Icon(Icons.event_note),
-                    const SizedBox(width: 4),
-                    Text(
-                      season.name.substring(10),
-                      style: const TextStyle(fontSize: 16),
-                    ),
-                    const Icon(Icons.arrow_right)
-                  ]))
-            ],
-          ),
-        ),
+      TeamPageHeader(
+        teamNumber: widget.teamNumber,
+        onSeason: () async {
+          if (!await _flushAnswerSave() || !mounted) return;
+          final updated = await Navigator.push<Season>(
+              context,
+              MaterialPageRoute(
+                builder: (_) => SeasonFilterPage(selected: season),
+              ));
+          if (updated == null || !mounted) return;
+          setState(() {
+            season = updated;
+            skillsStats = getWorldSkillsForTeam(season.vrcId, widget.teamID);
+            teamStats =
+                getTrueSkillDataForTeam(season.vrcId, widget.teamNumber);
+            teamTournaments = _fetchTournamentsForSeason(season);
+            teamAwards = getAwards(widget.teamID, season.vrcId);
+          });
+        },
       ),
       CustomTabBar(
-          tabs: ["Details", "Scoutsheet"],
+          initIndex: widget.openScoutSheet ? 1 : 0,
+          tabs: ["Details", "Scout sheet"],
           onPressed: (value) {
             setState(() {
               pageIndex = value;

--- a/elapse_app/test/group_setup_test.dart
+++ b/elapse_app/test/group_setup_test.dart
@@ -1,0 +1,99 @@
+import 'package:elapse_app/classes/Groups/teamGroup.dart';
+import 'package:elapse_app/main.dart' as app;
+import 'package:elapse_app/screens/settings/setup_group.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    app.prefs = await SharedPreferences.getInstance();
+  });
+
+  TeamGroup group() => TeamGroup(
+      groupId: 'test-group',
+      adminId: 'tester',
+      members: {'tester': 'Scout'},
+      joinCode: 'ABCD-1234',
+      groupName: 'Notebook');
+
+  testWidgets(
+      'creation validates input and returns the saved group to scouting',
+      (tester) async {
+    String? name;
+    TeamGroup? result;
+    await tester.pumpWidget(MaterialApp(
+        home: Builder(
+            builder: (context) => TextButton(
+                  onPressed: () async {
+                    result = await Navigator.push<TeamGroup>(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => GroupSetupPage(
+                                  returnToScouting: true,
+                                  createGroup: (value) async {
+                                    name = value;
+                                    return group();
+                                  },
+                                )));
+                  },
+                  child: const Text('Start'),
+                ))));
+    await tester.tap(find.text('Start'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Create group & continue scouting'));
+    await tester.pumpAndSettle();
+    expect(name, isNull);
+    expect(find.textContaining('Enter a group name'), findsOneWidget);
+    await tester.enterText(find.byType(TextField).first, ' Notebook ');
+    await tester.tap(find.text('Create group & continue scouting'));
+    await tester.pumpAndSettle();
+    expect(name, 'Notebook');
+    expect(result?.groupId, 'test-group');
+    expect(app.prefs.getString('teamGroup'), contains('test-group'));
+    expect(find.text('Start'), findsOneWidget);
+  });
+
+  testWidgets('failed creation stays on setup and never stores null',
+      (tester) async {
+    var completed = false;
+    await tester.pumpWidget(MaterialApp(
+        home: GroupSetupPage(
+            createGroup: (_) async => null,
+            onComplete: (_) => completed = true)));
+    await tester.enterText(find.byType(TextField).first, 'Notebook');
+    await tester.tap(find.text('Create group'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Could not create the group'), findsOneWidget);
+    expect(completed, false);
+    expect(app.prefs.getString('teamGroup'), isNull);
+  });
+
+  testWidgets('join validates short code and accepts pasted hyphenated code',
+      (tester) async {
+    String? submitted;
+    await tester.pumpWidget(MaterialApp(
+        home: GroupSetupPage(
+            joinGroup: (code) async {
+              submitted = code;
+              return group();
+            },
+            onComplete: (_) {})));
+    await tester.tap(find.text('Already have an invite code?'));
+    await tester.pumpAndSettle();
+    final field = find.widgetWithText(TextField, 'Invite code');
+    await tester.enterText(field, 'ab');
+    await tester.ensureVisible(find.text('Join group'));
+    await tester.tap(find.text('Join group'));
+    await tester.pumpAndSettle();
+    expect(submitted, isNull);
+    expect(find.textContaining('Enter the 8-letter'), findsOneWidget);
+    await tester.enterText(field, ' abcd-1234 ');
+    await tester.ensureVisible(find.text('Join group'));
+    await tester.tap(find.text('Join group'));
+    await tester.pumpAndSettle();
+    expect(submitted, 'ABCD-1234');
+    expect(app.prefs.getString('teamGroup'), contains('test-group'));
+  });
+}

--- a/elapse_app/test/scout_template_test.dart
+++ b/elapse_app/test/scout_template_test.dart
@@ -79,6 +79,20 @@ void main() {
   });
 
   group('ScoutSheetData', () {
+    test('deleted legacy photos stay deleted after a migrated sheet reloads',
+        () {
+      final legacy = <String, dynamic>{
+        'properties': {
+          'Specs': {
+            'photos': ['old-photo']
+          }
+        },
+      };
+      final migrated = ScoutSheetData.fromFirestore(legacy).withPhotos([]);
+      final persisted = {...legacy, ...migrated.toFirestore()};
+      expect(ScoutSheetData.fromFirestore(persisted).photos, isEmpty);
+    });
+
     test('migrates legacy Specs documents without losing answers', () {
       final sheet = ScoutSheetData.fromFirestore({
         'properties': {

--- a/elapse_app/test/scouted_sheets_test.dart
+++ b/elapse_app/test/scouted_sheets_test.dart
@@ -1,0 +1,131 @@
+import 'package:elapse_app/classes/ScoutSheet/scout_sheet_data.dart';
+import 'package:elapse_app/classes/ScoutSheet/scout_sheet_template.dart';
+import 'package:elapse_app/classes/ScoutSheet/scouted_sheet.dart';
+import 'package:elapse_app/classes/ScoutSheet/scouted_sheet_repository.dart';
+import 'package:elapse_app/main.dart' as app;
+import 'package:elapse_app/screens/scout/scouted_sheets.dart';
+import 'package:elapse_app/screens/team_screen/team_page_header.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    app.prefs = await SharedPreferences.getInstance();
+  });
+
+  ScoutedSheet row(String team) => ScoutedSheet(
+      id: team,
+      teamId: team == '10K' ? 143646 : 1523,
+      teamNumber: team,
+      eventId: 64244,
+      eventName: 'Test event',
+      data: ScoutSheetData.empty(ScoutSheetTemplate.standard)
+          .withAnswer('otherNotes', 'Test note for $team'));
+
+  test('table formatting preserves false, zero, and separate same-label fields',
+      () {
+    expect(ScoutedSheet.answerText(false), 'No');
+    expect(ScoutedSheet.answerText(0), '0');
+    expect(ScoutedSheet.answerText('  '), '—');
+    final template = ScoutSheetTemplate.standard.copyWith(fields: [
+      ScoutTemplateField(
+          id: 'one', label: 'Notes', type: ScoutFieldType.shortText),
+      ScoutTemplateField(
+          id: 'two', label: 'Notes', type: ScoutFieldType.shortText),
+    ]);
+    final sheet = ScoutedSheet(
+        id: 'id',
+        teamId: 1,
+        teamNumber: '1A',
+        eventId: 1,
+        eventName: 'Event',
+        data: ScoutSheetData.empty(template)
+            .withAnswer('one', 'First')
+            .withAnswer('two', 'Second'));
+    expect(sheet.answerColumns.values, ['First', 'Second']);
+  });
+
+  testWidgets('table shows both teams and opens the exact selected sheet',
+      (tester) async {
+    ScoutedSheet? opened;
+    await tester.pumpWidget(MaterialApp(
+        home: ScoutedSheetsScreen(
+            groupId: 'group',
+            loadPage: (_, __) async =>
+                ScoutedSheetPage([row('10K'), row('1523A')]),
+            onOpen: (value) => opened = value)));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Table'));
+    await tester.pumpAndSettle();
+    expect(find.byType(DataTable), findsOneWidget);
+    expect(find.text('10K'), findsOneWidget);
+    expect(find.text('1523A'), findsOneWidget);
+    expect(find.text('Test note for 10K'), findsOneWidget);
+    await tester.tap(find.text('1523A'));
+    expect(opened?.id, '1523A');
+    expect(app.prefs.getBool('scoutSheets.tableView'), true);
+  });
+
+  testWidgets('filtering and paginated loading keep both pages',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+        home: ScoutedSheetsScreen(
+            groupId: 'group',
+            loadPage: (_, cursor) async => cursor == null
+                ? ScoutedSheetPage([row('10K')], nextCursor: 'page2')
+                : ScoutedSheetPage([row('1523A')]))));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Load more (1 loaded)'));
+    await tester.pumpAndSettle();
+    expect(find.text('10K'), findsOneWidget);
+    expect(find.text('1523A'), findsOneWidget);
+    await tester.enterText(find.byType(TextField), '1523a');
+    await tester.pumpAndSettle();
+    expect(find.text('10K'), findsNothing);
+    expect(find.text('1523A'), findsOneWidget);
+  });
+
+  testWidgets('failed sheet load has a working retry', (tester) async {
+    var attempts = 0;
+    await tester.pumpWidget(MaterialApp(
+        home: ScoutedSheetsScreen(
+            groupId: 'group',
+            loadPage: (_, __) async {
+              if (++attempts == 1) throw StateError('offline');
+              return ScoutedSheetPage([row('10K')]);
+            })));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Could not load your sheets'), findsOneWidget);
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+    expect(find.text('10K'), findsOneWidget);
+  });
+
+  testWidgets('team title and back arrow never overlap while scrolling',
+      (tester) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(MaterialApp(
+        builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context)
+                .copyWith(textScaler: const TextScaler.linear(1.8)),
+            child: child!),
+        home: Scaffold(
+            body: CustomScrollView(slivers: [
+          TeamPageHeader(teamNumber: '1523W', onSeason: () {}),
+          const SliverToBoxAdapter(child: SizedBox(height: 1800)),
+        ]))));
+    expect(tester.getRect(find.byType(BackButton)).right,
+        lessThanOrEqualTo(tester.getRect(find.text('Team 1523W')).left));
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
+    await tester.pumpAndSettle();
+    expect(find.byType(BackButton), findsOneWidget);
+    expect(tester.getRect(find.byType(BackButton)).right,
+        lessThanOrEqualTo(tester.getRect(find.text('Team 1523W')).left));
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/elapse_app/test/start_scouting_test.dart
+++ b/elapse_app/test/start_scouting_test.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:elapse_app/classes/ScoutSheet/scout_sheet_template.dart';
+import 'package:elapse_app/classes/ScoutSheet/scout_template_repository.dart';
+import 'package:elapse_app/classes/Team/teamPreview.dart';
+import 'package:elapse_app/screens/scout/start_scouting.dart';
+import 'package:elapse_app/screens/scout/templates/scout_template_list.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('template actions remain usable on small screens with large text',
+      (tester) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    SharedPreferences.setMockInitialValues({});
+    final repository =
+        ScoutTemplateRepository(await SharedPreferences.getInstance());
+    await tester.pumpWidget(MaterialApp(
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context)
+            .copyWith(textScaler: const TextScaler.linear(1.5)),
+        child: child!,
+      ),
+      home: ScoutTemplateListScreen(repository: repository),
+    ));
+    await tester.scrollUntilVisible(
+        find.text('Use template').hitTestable(), 150);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Use template'));
+    await tester.pumpAndSettle();
+    expect(find.text('1. Choose a team'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Use template opens team selection without changing the default',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final repository =
+        ScoutTemplateRepository(await SharedPreferences.getInstance());
+    await tester.pumpWidget(
+        MaterialApp(home: ScoutTemplateListScreen(repository: repository)));
+    expect(find.textContaining('A template is a blank form.'), findsOneWidget);
+    await tester.tap(find.text('Use template'));
+    await tester.pumpAndSettle();
+    expect(find.text('1. Choose a team'), findsOneWidget);
+    expect(find.text('Using: Robot overview'), findsOneWidget);
+    expect(repository.loadDefaultTemplate().id, ScoutSheetTemplate.standard.id);
+    expect(find.byType(ScoutTemplateListScreen), findsNothing);
+    expect(find.widgetWithText(TextField, 'e.g. 1523W'), findsOneWidget);
+  });
+
+  testWidgets('in-sheet template manager returns the selected form',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final repository =
+        ScoutTemplateRepository(await SharedPreferences.getInstance());
+    ScoutSheetTemplate? selected;
+    await tester.pumpWidget(MaterialApp(
+        home: ScoutTemplateListScreen(
+            repository: repository,
+            onUseTemplate: (value) => selected = value)));
+    await tester.tap(find.text('Use template'));
+    await tester.pumpAndSettle();
+    expect(selected, ScoutSheetTemplate.standard);
+    expect(find.byType(StartScoutingScreen), findsNothing);
+  });
+
+  testWidgets(
+      'team selection preserves the chosen template and normalized search',
+      (tester) async {
+    String? query;
+    TeamPreview? selectedTeam;
+    ScoutSheetTemplate? selectedTemplate;
+    final template = ScoutSheetTemplate.standard
+        .copyWith(id: 'custom', name: 'Custom pit form', isBuiltIn: false);
+    await tester.pumpWidget(MaterialApp(
+        home: StartScoutingScreen(
+      template: template,
+      searchTeams: (value) async {
+        query = value;
+        return [
+          TeamPreview(teamID: 143646, teamNumber: '10K', teamName: 'Knockout')
+        ];
+      },
+      onTeamSelected: (team, form) {
+        selectedTeam = team;
+        selectedTemplate = form;
+      },
+    )));
+    await tester.enterText(find.byType(TextField), ' 10k ');
+    await tester.tap(find.text('Find team'));
+    await tester.pumpAndSettle();
+    expect(query, '10K');
+    await tester.tap(find.text('10K'));
+    expect(selectedTeam?.teamID, 143646);
+    expect(selectedTemplate, same(template));
+  });
+
+  testWidgets('empty query and no results explain the next action',
+      (tester) async {
+    var calls = 0;
+    await tester.pumpWidget(MaterialApp(
+        home: StartScoutingScreen(
+      template: ScoutSheetTemplate.standard,
+      searchTeams: (_) async {
+        calls++;
+        return [];
+      },
+    )));
+    await tester.tap(find.text('Find team'));
+    await tester.pumpAndSettle();
+    expect(calls, 0);
+    expect(find.text('Enter a team number, like 1523W.'), findsOneWidget);
+    await tester.enterText(find.byType(TextField), 'UNKNOWN');
+    await tester.tap(find.text('Find team'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('No teams found.'), findsOneWidget);
+  });
+
+  testWidgets('failed search can be retried', (tester) async {
+    var calls = 0;
+    await tester.pumpWidget(MaterialApp(
+        home: StartScoutingScreen(
+      template: ScoutSheetTemplate.standard,
+      searchTeams: (_) async {
+        if (++calls == 1) throw StateError('offline');
+        return [TeamPreview(teamID: 1, teamNumber: '1A')];
+      },
+    )));
+    await tester.enterText(find.byType(TextField), '1A');
+    await tester.tap(find.text('Find team'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Check your connection'), findsOneWidget);
+    await tester.tap(find.text('Find team'));
+    await tester.pumpAndSettle();
+    expect(find.text('1A'), findsWidgets);
+    expect(find.textContaining('Check your connection'), findsNothing);
+  });
+
+  testWidgets('leaving during search does not update disposed state',
+      (tester) async {
+    final pending = Completer<List<TeamPreview>>();
+    await tester.pumpWidget(MaterialApp(
+        home: StartScoutingScreen(
+      template: ScoutSheetTemplate.standard,
+      searchTeams: (_) => pending.future,
+    )));
+    await tester.enterText(find.byType(TextField), '10K');
+    await tester.tap(find.text('Find team'));
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    pending.complete([]);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/elapse_app/test/vex_api_live_test.dart
+++ b/elapse_app/test/vex_api_live_test.dart
@@ -13,7 +13,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  const hasToken = bool.hasEnvironment('VEX_API_TOKEN');
+  const runLive = bool.hasEnvironment('VEX_API_TOKEN') ||
+      bool.fromEnvironment('RUN_LIVE_API_TESTS');
 
   test(
     'team 10K loads every MOA feature from the live VEX API',
@@ -83,7 +84,8 @@ void main() {
           await getWorldSkillsRankings(204, gradeLevels['High School']!);
       expect(worldSkills, isNotEmpty);
     },
-    skip: hasToken ? false : 'Set VEX_API_TOKEN to run live API checks.',
+    skip:
+        runLive ? false : 'Set RUN_LIVE_API_TESTS=true to run live API checks.',
     timeout: const Timeout(Duration(minutes: 4)),
   );
 }


### PR DESCRIPTION
# Add guided scouting and saved sheet review

Connect custom templates to a guided scouting flow and add a table for reviewing saved sheets.

### What changed
- Guide users through selecting a team when starting scouting from a template.
- Add saved-sheet models, repository support, and a saved scouting table.
- Connect cloud scouting, template selection, and team screens to the new workflow.
- Streamline group setup and settings around the scouting entry points.
- Add regression coverage for group setup, starting scouting, and saved sheets.
- Document the scouting workflow.
- Include local regressions for group lifecycle, membership access boundaries, and deleted legacy photos after migration.
- Add explicit live API test opt-in and preserve the existing verification report.
- The report records three failing regressions on an older revision; current results remain unverified.

### How this improves the app
Templates lead directly into collecting data for a team, and saved scouting work has a dedicated place to review and reopen. This makes it easier to move from preparation to scouting and then back to previous observations.

### Stack and review scope
Merge order: #76 → #77 → #78 → #79 → #80

- Part 5 of 5. All parts must be merged in order to reproduce the local application.
- Intended incremental scope: 19 files changed, 1577 insertions(+), 403 deletions(-).
- [Review only this part's changes](https://github.com/UtkarshTewari24/elapse/compare/codex/review-4-custom-scout-sheets...codex/review-5-scouting-workflows).
- This PR currently targets upstream `main`. Its Files changed tab is cumulative until a maintainer publishes `codex/review-4-custom-scout-sheets` in `elapse-app/elapse` and retargets this PR to that branch, or the preceding parts land in `main`.
- Kept as a draft until the base dependency is resolved. Do not merge this part ahead of its predecessors.
- Replaces the overlapping work previously proposed in #74 and #75.

### Validation
- Diff whitespace checks pass and package-local imports resolve at this stage.
- The final stack includes the current local application files, including the previously uncommitted regression tests and verification report.
- Flutter tests and analysis were not rerun: the installed Flutter symlink does not resolve to an executable. Intermediate stages still need compilation and test validation.
- The included verification report describes an older source revision; its results are historical and have not been rerun for this stack.
